### PR TITLE
Add flight-dlt-ga4-ingest Flight Plan template

### DIFF
--- a/flight-plans/flight-dlt-ga4-ingest/README.md
+++ b/flight-plans/flight-dlt-ga4-ingest/README.md
@@ -10,7 +10,7 @@ description: >-
 type: template
 category: ingestion
 features: [flights]
-tags: [dlt, ingest, ga4, google-analytics]
+tags: [dlt, ingest]
 ---
 
 # Ingest Google Analytics 4 into MotherDuck with dlt as a Flight

--- a/flight-plans/flight-dlt-ga4-ingest/README.md
+++ b/flight-plans/flight-dlt-ga4-ingest/README.md
@@ -1,0 +1,226 @@
+---
+title: Ingest Google Analytics 4 into MotherDuck with dlt as a Flight
+id: flight-dlt-ga4-ingest
+description: >-
+  A reusable Flight that runs a dlt pipeline pulling Google Analytics 4 (GA4)
+  report data into MotherDuck on a schedule, with Parquet loader files, schema
+  evolution, and a run ledger. Use when you want scheduled GA4 reporting data
+  (sessions, users, pageviews by dimension) in MotherDuck without hand-writing
+  the API calls or INSERTs.
+type: template
+category: ingestion
+features: [flights]
+tags: [dlt, ingest, ga4, google-analytics]
+---
+
+# Ingest Google Analytics 4 into MotherDuck with dlt as a Flight
+
+A single-file Flight that runs a [dlt](https://dlthub.com/docs/dlt-ecosystem/destinations/motherduck)
+pipeline pulling **Google Analytics 4 (GA4)** report data into MotherDuck. It is
+the GA4 adaptation of [flight-dlt-ingest](../flight-dlt-ingest): the demo
+`repo_rows()` source is replaced with a `ga4_rows()` source that calls the GA4
+Data API, and the rest of the pattern — dlt-managed schema, Parquet loader files,
+a run ledger, and Flight scheduling — is unchanged.
+
+Everything is driven by Flight config, so you adapt it by setting config values,
+not by editing `flight.py`. The defaults pull the last 7 days of
+sessions/users/pageviews by default channel group from the GA4 property you set
+in `GA4_PROPERTY_ID`, and load it into `ga4_ingest.ga4.ga4_report` in your own
+account.
+
+## Aggregated reports, not raw events
+
+The GA4 Data API (`runReport`) returns **pre-aggregated report rows** — metrics
+like `sessions` and `totalUsers` broken down by dimensions like `date` and
+`sessionDefaultChannelGroup`. It **cannot** return raw, event-level data
+(individual `event_name` rows, event params, user properties).
+
+- Want **dashboards / KPI reporting**? This template is the right fit.
+- Want **raw GA4 events**? Use the native **GA4 → BigQuery export** and ingest
+  with [flight-bigquery-ingest](../flight-bigquery-ingest) instead.
+
+## How it works
+
+`flight.py` runs a fixed sequence; the config values only change its inputs:
+
+1. Set `HOME=/tmp` (dlt writes working files under `HOME`, and a Flight has a
+   writable `/tmp`) and point the dlt MotherDuck destination at
+   `DESTINATION_DATABASE` through an environment variable, so no token is written
+   anywhere.
+2. Connect to MotherDuck (`md:`) and `CREATE DATABASE IF NOT EXISTS` the
+   destination, because dlt creates the dataset and tables but not the database.
+3. Build a dlt pipeline and `run()` the `ga4_rows()` source with
+   `loader_file_format="parquet"` and the configured write disposition and
+   primary key.
+4. Append one row to the run ledger capturing the dlt load package summary.
+
+`ga4_rows()` authenticates with a Google service account, calls the GA4 Data API
+`runReport` for the configured property, dimensions, metrics, and date range, and
+yields one dict per report row. It pages through results in 10k-row pages (the
+GA4 per-request cap) until the full `row_count` is read.
+
+## Why this dlt setup
+
+The important default is the load format. For MotherDuck, prefer Parquet loader
+files over row-wise `insert_values`, so larger sources stay on a bulk-loading
+path. The Flight makes that choice explicit with `loader_file_format="parquet"`.
+
+The second important default is **`merge` on the dimension columns over a moving
+lookback window**. GA4 keeps revising recent days as attribution and conversion
+windows settle (often for 48 hours to two weeks). Re-pulling `7daysAgo`→`yesterday`
+on every run and merging on the dimension columns means a recent day's row gets
+*corrected* on later runs instead of frozen wrong (`append` would double-count,
+`replace` would discard history).
+
+## Adapt the pattern
+
+- Set `GA4_PROPERTY_ID` to your numeric GA4 property id.
+- Choose your grain with `GA4_DIMENSIONS` and `GA4_METRICS`. The dimension list
+  is effectively the table's grain and the default merge key, so plan it up front
+  — adding a dimension later changes the key.
+- Tune the lookback with `GA4_START_DATE` / `GA4_END_DATE`. GA4 accepts relative
+  strings (`7daysAgo`, `yesterday`, `today`) as well as `YYYY-MM-DD`.
+- Use `WRITE_DISPOSITION=merge` with the dimension columns as `PRIMARY_KEY`
+  (default) for self-healing reports; `replace` if you re-pull the full range
+  each run; `append` only if you truly want an immutable log of pulls.
+- Keep `loader_file_format="parquet"` unless you have measured a reason to change
+  it. See the [dlt MotherDuck destination docs](https://dlthub.com/docs/dlt-ecosystem/destinations/motherduck).
+
+## Questions to answer
+
+- Which GA4 **property** (numeric id), and which **dimensions/metrics** (the grain)?
+- What **lookback window** matches how late your GA4 data settles?
+- Target MotherDuck database and dataset (`DESTINATION_DATABASE`, `DATASET_NAME`);
+  is letting the Flight create the database acceptable?
+- Load behavior: `merge` on the dimensions (default), `replace`, or `append`?
+- Which service account token, and is the GA4 service-account key stored as a
+  Flights secret (not config)?
+- What schedule (cron) should it run on?
+
+## Prerequisites (Google side)
+
+1. **Enable the Google Analytics Data API** in a GCP project.
+2. **Create a service account** and download its JSON key.
+3. In **GA4 Admin → Property Access Management**, add the service account's email
+   as a **Viewer** on the property. (API enabled but service account not granted
+   on the property is the most common cause of a `403`.)
+4. Note the **numeric GA4 Property ID** (Admin → Property Settings), e.g.
+   `123456789` — not the `G-XXXXXXX` measurement id.
+
+## Caveats
+
+- **Aggregated, not raw.** See [Aggregated reports, not raw events](#aggregated-reports-not-raw-events).
+- **dlt does not create the database.** It creates the dataset (schema) and
+  tables, so the Flight pre-creates `DESTINATION_DATABASE` with
+  `CREATE DATABASE IF NOT EXISTS`.
+- **`merge` needs a primary key.** With `WRITE_DISPOSITION=merge`, `PRIMARY_KEY`
+  defaults to the dimension columns; keep it aligned with your grain or switch to
+  `append`/`replace`.
+- **Keep source credentials out of config.** The GA4 service-account key is a
+  secret. Add it as a MotherDuck **Flights secret** named `GA4_SERVICE_ACCOUNT_JSON`
+  (the simplest way is the MotherDuck UI at
+  [Settings > Secrets](https://app.motherduck.com/settings/secrets), or
+  `CREATE SECRET ... (TYPE flights, ...)` from the DuckDB client), which the
+  runtime injects as an env var you read with `os.environ`.
+- **Keep the token out of config.** The runtime attaches a MotherDuck token and
+  injects it as `MOTHERDUCK_TOKEN`; never place a token in `config`.
+
+## What you'll adjust
+
+Every knob is a config/env value read at the top of `flight.py`. Set them as
+Flight config, not by editing code. The source itself lives in the `ga4_rows()`
+function.
+
+| Config key | Default | Purpose |
+|---|---|---|
+| `GA4_PROPERTY_ID` | (required) | Numeric GA4 property id, e.g. `123456789`. Validated as digits. |
+| `GA4_DIMENSIONS` | `date,sessionDefaultChannelGroup` | Comma-separated GA4 dimension API names. Defines the grain and default merge key. |
+| `GA4_METRICS` | `sessions,totalUsers,screenPageViews` | Comma-separated GA4 metric API names. Loaded as numbers. |
+| `GA4_START_DATE` | `7daysAgo` | Report start date. Relative (`NdaysAgo`, `yesterday`, `today`) or `YYYY-MM-DD`. |
+| `GA4_END_DATE` | `yesterday` | Report end date. Same formats as `GA4_START_DATE`. |
+| `DESTINATION_DATABASE` | `ga4_ingest` | MotherDuck database dlt loads into. Created if missing. Validated as a SQL identifier. |
+| `DATASET_NAME` | `ga4` | dlt dataset (schema) that holds the loaded tables. |
+| `TABLE_NAME` | `ga4_report` | dlt table name for the loaded rows. |
+| `WRITE_DISPOSITION` | `merge` | `merge` (default; merges on `PRIMARY_KEY`), `append`, or `replace`. |
+| `PRIMARY_KEY` | `GA4_DIMENSIONS` | Merge key when `WRITE_DISPOSITION=merge`. Defaults to the dimension columns. |
+| `PIPELINE_NAME` | `ga4_dlt_ingest` | dlt pipeline name (also used for dlt state). |
+| `RUN_LEDGER_TABLE` | `dlt_ingest_runs` | Audit table in the database's `main` schema. Validated as a SQL identifier. |
+| `GA4_SERVICE_ACCOUNT_JSON` | (Flights secret) | Service-account key JSON. Store as a Flights **secret**, never in config. |
+| `MOTHERDUCK_TOKEN` | (Flight-injected) | Auth. Select a token on the Flight; never put it in config. |
+
+## Run it
+
+You need a MotherDuck account and access token, a GA4 property, and a service
+account with Viewer access on that property (see
+[Prerequisites](#prerequisites-google-side)).
+
+To smoke-test the pipeline locally before deploying, run the file directly
+against your account, supplying the GA4 key inline:
+
+```bash
+export MOTHERDUCK_TOKEN=your_token_here
+export GA4_SERVICE_ACCOUNT_JSON="$(cat service-account.json)"
+GA4_PROPERTY_ID=123456789 uv run --with-requirements requirements.txt flight.py
+```
+
+That single run creates the `ga4_ingest` database, loads the last 7 days of the
+default report into `ga4.ga4_report`, and writes one ledger row. Override any
+default inline, for example:
+
+```bash
+GA4_PROPERTY_ID=123456789 \
+GA4_DIMENSIONS=date,country,deviceCategory \
+GA4_METRICS=sessions,engagedSessions,conversions \
+uv run --with-requirements requirements.txt flight.py
+```
+
+### Deploy as a Flight
+
+Create the Flight with the `MD_CREATE_FLIGHT` SQL function (no deploy SQL is
+checked in; adapt the arguments to your situation), passing:
+
+- `name`: a Flight name, for example `ga4_dlt_ingest`
+- `source_code`: the contents of [`flight.py`](flight.py)
+- `requirements_txt`: the contents of [`requirements.txt`](requirements.txt)
+- `config`: the keys from [What you'll adjust](#what-youll-adjust) you want to
+  override (at minimum `GA4_PROPERTY_ID`; omit any you are keeping at default)
+
+Before the first run, add the `GA4_SERVICE_ACCOUNT_JSON` Flights secret (UI:
+[Settings > Secrets](https://app.motherduck.com/settings/secrets), or
+`CREATE SECRET ... (TYPE flights, ...)`), and select a MotherDuck token on the
+Flight (injected at run time as `MOTHERDUCK_TOKEN`).
+
+Create the Flight without a schedule first, trigger one manual run with
+`MD_RUN_FLIGHT(flight_id := ...)` (the id is returned by `MD_CREATE_FLIGHT` and
+listed by `MD_FLIGHTS()`), and confirm it succeeds and the GA4 tables and ledger
+row appear. Once the manual run is green, add a daily schedule (`15 7 * * *`,
+07:15 UTC, is a reasonable default) by updating the Flight's `schedule_cron` with
+`MD_UPDATE_FLIGHT`. Schedule updates are metadata-only and do not create a new
+Flight version.
+
+## Security
+
+- **Identifier validation.** `DESTINATION_DATABASE` and `RUN_LEDGER_TABLE` flow
+  into `CREATE`/`INSERT` statements that cannot be parameterized, so each is
+  checked against `^[A-Za-z_][A-Za-z0-9_]*$` before any SQL runs.
+  `GA4_PROPERTY_ID` is validated as digits.
+- **Parameterized data.** The ledger row (pipeline name, dataset, table, and load
+  summary) is written with bound parameters, never string-formatted into SQL.
+- **Secret handling.** The GA4 service-account key is read from the
+  `GA4_SERVICE_ACCOUNT_JSON` env var supplied by a Flights secret; it is never
+  written to disk by the Flight or placed in config.
+
+## Learn more
+
+- Flight mechanics (creating, running, scheduling): use the MotherDuck MCP
+  `get_flight_guide` tool.
+- dlt sources, write dispositions, and the MotherDuck destination:
+  [dlt MotherDuck destination docs](https://dlthub.com/docs/dlt-ecosystem/destinations/motherduck).
+- GA4 Data API dimensions and metrics:
+  [GA4 Dimensions & Metrics reference](https://developers.google.com/analytics/devguides/reporting/data/v1/api-schema).
+- The base template this adapts: [flight-dlt-ingest](../flight-dlt-ingest).
+- For raw event-level GA4 data: [flight-bigquery-ingest](../flight-bigquery-ingest)
+  via the GA4 → BigQuery export.
+- Files in this template: [`flight.py`](flight.py) (the single-file Flight source)
+  and [`requirements.txt`](requirements.txt) (`duckdb`, `dlt[motherduck]`,
+  `google-analytics-data`).

--- a/flight-plans/flight-dlt-ga4-ingest/README.md
+++ b/flight-plans/flight-dlt-ga4-ingest/README.md
@@ -37,7 +37,7 @@ like `sessions` and `totalUsers` broken down by dimensions like `date` and
 
 - Want **dashboards / KPI reporting**? This template is the right fit.
 - Want **raw GA4 events**? Use the native **GA4 → BigQuery export** and ingest
-  with [flight-bigquery-ingest](../flight-bigquery-ingest) instead.
+  with [the GA4 BigQuery Flight](../flight-ga4-bigquery-ingest/) instead.
 
 ## How it works
 
@@ -50,14 +50,14 @@ like `sessions` and `totalUsers` broken down by dimensions like `date` and
 2. Connect to MotherDuck (`md:`) and `CREATE DATABASE IF NOT EXISTS` the
    destination, because dlt creates the dataset and tables but not the database.
 3. Build a dlt pipeline and `run()` the `ga4_rows()` source with
-   `loader_file_format="parquet"` and the configured write disposition and
-   primary key.
+   `loader_file_format="parquet"`. In merge mode, the date is the merge key and
+   the configured dimension columns are the primary key.
 4. Append one row to the run ledger capturing the dlt load package summary.
 
 `ga4_rows()` authenticates with a Google service account, calls the GA4 Data API
 `runReport` for the configured property, dimensions, metrics, and date range, and
-yields one dict per report row. It pages through results in 10k-row pages (the
-GA4 per-request cap) until the full `row_count` is read.
+yields one dict per report row. It requests the GA4 maximum of 250,000 rows per
+page, then continues until it reads the full `row_count`.
 
 ## Why this dlt setup
 
@@ -65,24 +65,24 @@ The important default is the load format. For MotherDuck, prefer Parquet loader
 files over row-wise `insert_values`, so larger sources stay on a bulk-loading
 path. The Flight makes that choice explicit with `loader_file_format="parquet"`.
 
-The second important default is **`merge` on the dimension columns over a moving
-lookback window**. GA4 keeps revising recent days as attribution and conversion
-windows settle (often for 48 hours to two weeks). Re-pulling `7daysAgo`→`yesterday`
-on every run and merging on the dimension columns means a recent day's row gets
-*corrected* on later runs instead of frozen wrong (`append` would double-count,
-`replace` would discard history).
+The second important default is **a date-partition merge over a moving lookback
+window**. GA4 keeps revising recent days as attribution and conversion windows
+settle. Re-pulling `7daysAgo`→`yesterday` replaces each returned date partition.
+For each returned date, that corrects changed rows and removes rows that
+disappear from a revised report.
+`append` would double-count, while `replace` would discard history.
 
 ## Adapt the pattern
 
 - Set `GA4_PROPERTY_ID` to your numeric GA4 property id.
-- Choose your grain with `GA4_DIMENSIONS` and `GA4_METRICS`. The dimension list
-  is effectively the table's grain and the default merge key, so plan it up front
-  — adding a dimension later changes the key.
+- Choose your grain with `GA4_DIMENSIONS` and `GA4_METRICS`. Keep `date` in
+  `GA4_DIMENSIONS` when using the default merge mode. The dimension list is the
+  primary key, so adding a dimension later changes the table grain.
 - Tune the lookback with `GA4_START_DATE` / `GA4_END_DATE`. GA4 accepts relative
   strings (`7daysAgo`, `yesterday`, `today`) as well as `YYYY-MM-DD`.
-- Use `WRITE_DISPOSITION=merge` with the dimension columns as `PRIMARY_KEY`
-  (default) for self-healing reports; `replace` if you re-pull the full range
-  each run; `append` only if you truly want an immutable log of pulls.
+- Use `WRITE_DISPOSITION=merge` with `date` plus the other dimension columns as
+  `PRIMARY_KEY` for date-partition replacement. Use `replace` if you re-pull the
+  full range each run, or `append` only for an immutable pull log.
 - Keep `loader_file_format="parquet"` unless you have measured a reason to change
   it. See the [dlt MotherDuck destination docs](https://dlthub.com/docs/dlt-ecosystem/destinations/motherduck).
 
@@ -92,7 +92,8 @@ on every run and merging on the dimension columns means a recent day's row gets
 - What **lookback window** matches how late your GA4 data settles?
 - Target MotherDuck database and dataset (`DESTINATION_DATABASE`, `DATASET_NAME`);
   is letting the Flight create the database acceptable?
-- Load behavior: `merge` on the dimensions (default), `replace`, or `append`?
+- Load behavior: date-partition `merge` with dimensions as the row key
+  (default), `replace`, or `append`?
 - Which service account token, and is the GA4 service-account key stored as a
   Flights secret (not config)?
 - What schedule (cron) should it run on?
@@ -113,15 +114,14 @@ on every run and merging on the dimension columns means a recent day's row gets
 - **dlt does not create the database.** It creates the dataset (schema) and
   tables, so the Flight pre-creates `DESTINATION_DATABASE` with
   `CREATE DATABASE IF NOT EXISTS`.
-- **`merge` needs a primary key.** With `WRITE_DISPOSITION=merge`, `PRIMARY_KEY`
-  defaults to the dimension columns; keep it aligned with your grain or switch to
-  `append`/`replace`.
+- **`merge` needs `date` and a primary key.** With `WRITE_DISPOSITION=merge`,
+  `GA4_DIMENSIONS` must include `date` so the Flight can replace each returned
+  date partition. `PRIMARY_KEY` defaults to the dimension columns. Keep it
+  aligned with your grain or switch to `append`/`replace`.
 - **Keep source credentials out of config.** The GA4 service-account key is a
-  secret. Add it as a MotherDuck **Flights secret** named `GA4_SERVICE_ACCOUNT_JSON`
-  (the simplest way is the MotherDuck UI at
-  [Settings > Secrets](https://app.motherduck.com/settings/secrets), or
-  `CREATE SECRET ... (TYPE flights, ...)` from the DuckDB client), which the
-  runtime injects as an env var you read with `os.environ`.
+  secret. Add a `GA4_SERVICE_ACCOUNT_JSON` parameter to a MotherDuck **Flights
+  secret**, then attach that secret to the Flight through `flight_secret_names`.
+  The Flight reads the attached, prefixed environment variable.
 - **Keep the token out of config.** The runtime attaches a MotherDuck token and
   injects it as `MOTHERDUCK_TOKEN`; never place a token in `config`.
 
@@ -134,15 +134,15 @@ function.
 | Config key | Default | Purpose |
 |---|---|---|
 | `GA4_PROPERTY_ID` | (required) | Numeric GA4 property id, e.g. `123456789`. Validated as digits. |
-| `GA4_DIMENSIONS` | `date,sessionDefaultChannelGroup` | Comma-separated GA4 dimension API names. Defines the grain and default merge key. |
-| `GA4_METRICS` | `sessions,totalUsers,screenPageViews` | Comma-separated GA4 metric API names. Loaded as numbers. |
+| `GA4_DIMENSIONS` | `date,sessionDefaultChannelGroup` | Comma-separated GA4 dimension API names. Defines the grain. Must include `date` in merge mode. |
+| `GA4_METRICS` | `sessions,totalUsers,screenPageViews` | Comma-separated GA4 metric API names. The Flight preserves integer and currency values, and loads other metric types as doubles. |
 | `GA4_START_DATE` | `7daysAgo` | Report start date. Relative (`NdaysAgo`, `yesterday`, `today`) or `YYYY-MM-DD`. |
 | `GA4_END_DATE` | `yesterday` | Report end date. Same formats as `GA4_START_DATE`. |
 | `DESTINATION_DATABASE` | `ga4_ingest` | MotherDuck database dlt loads into. Created if missing. Validated as a SQL identifier. |
 | `DATASET_NAME` | `ga4` | dlt dataset (schema) that holds the loaded tables. |
 | `TABLE_NAME` | `ga4_report` | dlt table name for the loaded rows. |
-| `WRITE_DISPOSITION` | `merge` | `merge` (default; merges on `PRIMARY_KEY`), `append`, or `replace`. |
-| `PRIMARY_KEY` | `GA4_DIMENSIONS` | Merge key when `WRITE_DISPOSITION=merge`. Defaults to the dimension columns. |
+| `WRITE_DISPOSITION` | `merge` | `merge` (default; replaces returned date partitions), `append`, or `replace`. |
+| `PRIMARY_KEY` | `GA4_DIMENSIONS` | Row key in merge mode. Defaults to the dimension columns. |
 | `PIPELINE_NAME` | `ga4_dlt_ingest` | dlt pipeline name (also used for dlt state). |
 | `RUN_LEDGER_TABLE` | `dlt_ingest_runs` | Audit table in the database's `main` schema. Validated as a SQL identifier. |
 | `GA4_SERVICE_ACCOUNT_JSON` | (Flights secret) | Service-account key JSON. Store as a Flights **secret**, never in config. |
@@ -182,13 +182,17 @@ checked in; adapt the arguments to your situation), passing:
 - `name`: a Flight name, for example `ga4_dlt_ingest`
 - `source_code`: the contents of [`flight.py`](flight.py)
 - `requirements_txt`: the contents of [`requirements.txt`](requirements.txt)
+- `flight_secret_names`: `["ga4_creds"]` so the `GA4_SERVICE_ACCOUNT_JSON`
+  parameter is injected as `ga4_creds_GA4_SERVICE_ACCOUNT_JSON`
 - `config`: the keys from [What you'll adjust](#what-youll-adjust) you want to
   override (at minimum `GA4_PROPERTY_ID`; omit any you are keeping at default)
 
-Before the first run, add the `GA4_SERVICE_ACCOUNT_JSON` Flights secret (UI:
-[Settings > Secrets](https://app.motherduck.com/settings/secrets), or
-`CREATE SECRET ... (TYPE flights, ...)`), and select a MotherDuck token on the
-Flight (injected at run time as `MOTHERDUCK_TOKEN`).
+Before the first run, create the `ga4_creds` Flights secret with a
+`GA4_SERVICE_ACCOUNT_JSON` parameter. You can create it in
+[Settings > Secrets](https://app.motherduck.com/settings/secrets) or with
+`CREATE SECRET ... (TYPE flights, ...)`. Then attach it through
+`flight_secret_names` and select a MotherDuck token. The runtime injects the
+token as `MOTHERDUCK_TOKEN`.
 
 Create the Flight without a schedule first, trigger one manual run with
 `MD_RUN_FLIGHT(flight_id := ...)` (the id is returned by `MD_CREATE_FLIGHT` and
@@ -206,9 +210,9 @@ Flight version.
   `GA4_PROPERTY_ID` is validated as digits.
 - **Parameterized data.** The ledger row (pipeline name, dataset, table, and load
   summary) is written with bound parameters, never string-formatted into SQL.
-- **Secret handling.** The GA4 service-account key is read from the
-  `GA4_SERVICE_ACCOUNT_JSON` env var supplied by a Flights secret; it is never
-  written to disk by the Flight or placed in config.
+- **Secret handling.** The GA4 service-account key is read from a prefixed
+  environment variable supplied by an attached Flights secret, or the unprefixed
+  local value during development. It is never written to disk or placed in config.
 
 ## Learn more
 
@@ -219,8 +223,9 @@ Flight version.
 - GA4 Data API dimensions and metrics:
   [GA4 Dimensions & Metrics reference](https://developers.google.com/analytics/devguides/reporting/data/v1/api-schema).
 - The base template this adapts: [flight-dlt-ingest](../flight-dlt-ingest).
-- For raw event-level GA4 data: [flight-bigquery-ingest](../flight-bigquery-ingest)
-  via the GA4 → BigQuery export.
+- For raw event-level GA4 data:
+  [the GA4 BigQuery Flight](../flight-ga4-bigquery-ingest/) via the GA4 →
+  BigQuery export.
 - Files in this template: [`flight.py`](flight.py) (the single-file Flight source)
   and [`requirements.txt`](requirements.txt) (`duckdb`, `dlt[motherduck]`,
   `google-analytics-data`).

--- a/flight-plans/flight-dlt-ga4-ingest/README.md
+++ b/flight-plans/flight-dlt-ga4-ingest/README.md
@@ -11,6 +11,13 @@ type: template
 category: ingestion
 features: [flights]
 tags: [dlt, ingest]
+prompt: >-
+  I want scheduled GA4 reporting data in MotherDuck without hand-writing API
+  calls or INSERTs. Help me adapt the "Ingest Google Analytics 4 into
+  MotherDuck with dlt as a Flight" recipe to my own data and use case, using
+  it as a guide:
+  https://motherduck.com/docs/cookbook/flight-dlt-ga4-ingest
+published_date: 2026-06-16
 ---
 
 # Ingest Google Analytics 4 into MotherDuck with dlt as a Flight

--- a/flight-plans/flight-dlt-ga4-ingest/flight.py
+++ b/flight-plans/flight-dlt-ga4-ingest/flight.py
@@ -1,0 +1,183 @@
+import json
+import os
+import re
+from collections.abc import Iterator
+
+import dlt
+import duckdb
+
+
+IDENTIFIER_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
+WRITE_DISPOSITIONS = {"append", "merge", "replace"}
+
+
+def ga4_rows(
+    property_id: str,
+    dimensions: list[str],
+    metrics: list[str],
+    start_date: str,
+    end_date: str,
+) -> Iterator[dict]:
+    # GA4 source: aggregated report rows from the GA4 Data API (runReport). Each
+    # yielded dict is one dimension-combination with its metric values, and dlt
+    # infers and evolves the schema from these dicts.
+    #
+    # This is the aggregated reporting surface (sessions, users, pageviews, etc.
+    # by dimension) -- NOT raw events. If you need event-level GA4 data, use the
+    # native GA4 -> BigQuery export with the flight-bigquery-ingest template
+    # instead; the Data API cannot return raw events.
+    #
+    # Credentials come from the GA4_SERVICE_ACCOUNT_JSON Flights secret (the full
+    # service-account key JSON), read from the environment -- never from config.
+    from google.analytics.data_v1beta import BetaAnalyticsDataClient
+    from google.analytics.data_v1beta.types import (
+        DateRange,
+        Dimension,
+        Metric,
+        RunReportRequest,
+    )
+    from google.oauth2 import service_account
+
+    sa_info = json.loads(os.environ["GA4_SERVICE_ACCOUNT_JSON"])
+    credentials = service_account.Credentials.from_service_account_info(
+        sa_info,
+        scopes=["https://www.googleapis.com/auth/analytics.readonly"],
+    )
+    client = BetaAnalyticsDataClient(credentials=credentials)
+
+    # GA4 caps a single report page at 10k rows; page through with offset until
+    # we have read row_count rows.
+    page_size, offset = 10000, 0
+    while True:
+        response = client.run_report(
+            RunReportRequest(
+                property=f"properties/{property_id}",
+                dimensions=[Dimension(name=name) for name in dimensions],
+                metrics=[Metric(name=name) for name in metrics],
+                date_ranges=[DateRange(start_date=start_date, end_date=end_date)],
+                limit=page_size,
+                offset=offset,
+            )
+        )
+        for row in response.rows:
+            record = {
+                dim: row.dimension_values[i].value
+                for i, dim in enumerate(dimensions)
+            }
+            for i, metric in enumerate(metrics):
+                raw = row.metric_values[i].value
+                record[metric] = float(raw) if raw not in (None, "") else None
+            yield record
+
+        offset += page_size
+        if offset >= response.row_count:
+            break
+
+
+def main() -> None:
+    # Every knob is read from Flight config/env, so you adapt this template by
+    # setting config values rather than editing code. Defaults pull the last 7
+    # days of sessions/users/pageviews by channel from the GA4 property set in
+    # GA4_PROPERTY_ID into ga4_ingest.ga4.ga4_report in your own account.
+    database = validate_identifier("DESTINATION_DATABASE", env("DESTINATION_DATABASE", "ga4_ingest"))
+    dataset_name = env("DATASET_NAME", "ga4")
+    table_name = env("TABLE_NAME", "ga4_report")
+    pipeline_name = env("PIPELINE_NAME", "ga4_dlt_ingest")
+    write_disposition = env("WRITE_DISPOSITION", "merge")
+    if write_disposition not in WRITE_DISPOSITIONS:
+        raise ValueError(
+            f"WRITE_DISPOSITION must be one of {sorted(WRITE_DISPOSITIONS)}, got {write_disposition!r}"
+        )
+    ledger_table = validate_identifier("RUN_LEDGER_TABLE", env("RUN_LEDGER_TABLE", "dlt_ingest_runs"))
+
+    # GA4 source inputs.
+    property_id = env("GA4_PROPERTY_ID", "")
+    if not property_id.isdigit():
+        raise ValueError(
+            f"GA4_PROPERTY_ID must be the numeric GA4 property id, got {property_id!r}"
+        )
+    dimensions = [
+        dim.strip()
+        for dim in env("GA4_DIMENSIONS", "date,sessionDefaultChannelGroup").split(",")
+        if dim.strip()
+    ]
+    metrics = [
+        metric.strip()
+        for metric in env("GA4_METRICS", "sessions,totalUsers,screenPageViews").split(",")
+        if metric.strip()
+    ]
+    start_date = env("GA4_START_DATE", "7daysAgo")
+    end_date = env("GA4_END_DATE", "yesterday")
+    # Merge key defaults to the dimension columns, so re-pulling a lookback window
+    # heals GA4's late-arriving data instead of duplicating or freezing it.
+    primary_key = [
+        key.strip()
+        for key in env("PRIMARY_KEY", ",".join(dimensions)).split(",")
+        if key.strip()
+    ]
+
+    # dlt writes working files under HOME; a Flight has a writable /tmp.
+    os.environ.setdefault("HOME", "/tmp")
+    # Point the dlt MotherDuck destination at our database. The injected
+    # MOTHERDUCK_TOKEN supplies the credential, so no token appears here.
+    os.environ["DESTINATION__MOTHERDUCK__CREDENTIALS__DATABASE"] = database
+
+    # Create the destination database so dlt has a catalog to build the dataset in;
+    # dlt creates the dataset (schema) and tables, but not the database itself.
+    con = duckdb.connect("md:")
+    con.execute(f"CREATE DATABASE IF NOT EXISTS {database}")
+
+    pipeline = dlt.pipeline(
+        pipeline_name=pipeline_name,
+        destination="motherduck",
+        dataset_name=dataset_name,
+    )
+    load_info = pipeline.run(
+        ga4_rows(property_id, dimensions, metrics, start_date, end_date),
+        table_name=table_name,
+        write_disposition=write_disposition,
+        primary_key=primary_key,
+        # Prefer Parquet loader files over row-wise insert_values so larger
+        # sources stay on a bulk-loading path. Keep this unless you have measured
+        # a reason to change it.
+        loader_file_format="parquet",
+    )
+
+    # Record the dlt load package summary so each run leaves an audit trail. The
+    # ledger lives in the database's main schema, separate from the dlt dataset.
+    con.execute(f"CREATE SCHEMA IF NOT EXISTS {database}.main")
+    con.execute(
+        f"""
+        CREATE TABLE IF NOT EXISTS {database}.main.{ledger_table} (
+            run_at TIMESTAMPTZ,
+            pipeline_name VARCHAR,
+            destination_dataset VARCHAR,
+            destination_table VARCHAR,
+            load_summary VARCHAR
+        )
+        """
+    )
+    con.execute(
+        f"INSERT INTO {database}.main.{ledger_table} VALUES (current_timestamp, ?, ?, ?, ?)",
+        [pipeline_name, dataset_name, table_name, str(load_info)],
+    )
+    con.close()
+    print(load_info)
+
+
+def env(name: str, default: str) -> str:
+    value = os.environ.get(name, default).strip()
+    return value or default
+
+
+def validate_identifier(name: str, value: str) -> str:
+    # The database and ledger table names flow into CREATE/INSERT statements that
+    # cannot be parameterized, so reject anything that is not a plain SQL
+    # identifier before any SQL runs.
+    if not IDENTIFIER_RE.fullmatch(value):
+        raise ValueError(f"{name} must be a simple SQL identifier, got {value!r}")
+    return value
+
+
+if __name__ == "__main__":
+    main()

--- a/flight-plans/flight-dlt-ga4-ingest/flight.py
+++ b/flight-plans/flight-dlt-ga4-ingest/flight.py
@@ -2,6 +2,7 @@ import json
 import os
 import re
 from collections.abc import Iterator
+from decimal import Decimal
 
 import dlt
 import duckdb
@@ -24,30 +25,38 @@ def ga4_rows(
     #
     # This is the aggregated reporting surface (sessions, users, pageviews, etc.
     # by dimension) -- NOT raw events. If you need event-level GA4 data, use the
-    # native GA4 -> BigQuery export with the flight-bigquery-ingest template
+    # native GA4 -> BigQuery export with the flight-ga4-bigquery-ingest template
     # instead; the Data API cannot return raw events.
     #
-    # Credentials come from the GA4_SERVICE_ACCOUNT_JSON Flights secret (the full
-    # service-account key JSON), read from the environment -- never from config.
+    # Credentials come from a local GA4_SERVICE_ACCOUNT_JSON environment value or
+    # a prefixed value injected by an attached Flights secret, never from config.
     from google.analytics.data_v1beta import BetaAnalyticsDataClient
     from google.analytics.data_v1beta.types import (
         DateRange,
         Dimension,
         Metric,
+        MetricType,
         RunReportRequest,
     )
     from google.oauth2 import service_account
 
-    sa_info = json.loads(os.environ["GA4_SERVICE_ACCOUNT_JSON"])
+    service_account_json = flight_secret_value("GA4_SERVICE_ACCOUNT_JSON")
+    if not service_account_json:
+        raise RuntimeError(
+            "Set GA4_SERVICE_ACCOUNT_JSON locally, or attach a TYPE flights secret "
+            "with a GA4_SERVICE_ACCOUNT_JSON parameter."
+        )
+    sa_info = json.loads(service_account_json)
     credentials = service_account.Credentials.from_service_account_info(
         sa_info,
         scopes=["https://www.googleapis.com/auth/analytics.readonly"],
     )
     client = BetaAnalyticsDataClient(credentials=credentials)
 
-    # GA4 caps a single report page at 10k rows; page through with offset until
-    # we have read row_count rows.
-    page_size, offset = 10000, 0
+    # GA4 returns up to 250k rows per report request. Page until we have read
+    # the full response so high-cardinality reports do not waste quota on small
+    # default pages.
+    page_size, offset = 250_000, 0
     while True:
         response = client.run_report(
             RunReportRequest(
@@ -57,6 +66,7 @@ def ga4_rows(
                 date_ranges=[DateRange(start_date=start_date, end_date=end_date)],
                 limit=page_size,
                 offset=offset,
+                keep_empty_rows=True,
             )
         )
         for row in response.rows:
@@ -66,7 +76,15 @@ def ga4_rows(
             }
             for i, metric in enumerate(metrics):
                 raw = row.metric_values[i].value
-                record[metric] = float(raw) if raw not in (None, "") else None
+                metric_type = response.metric_headers[i].type
+                if raw in (None, ""):
+                    record[metric] = None
+                elif metric_type in {MetricType.TYPE_INTEGER, MetricType.TYPE_MILLISECONDS}:
+                    record[metric] = int(raw)
+                elif metric_type == MetricType.TYPE_CURRENCY:
+                    record[metric] = Decimal(raw)
+                else:
+                    record[metric] = float(raw)
             yield record
 
         offset += page_size
@@ -108,13 +126,18 @@ def main() -> None:
     ]
     start_date = env("GA4_START_DATE", "7daysAgo")
     end_date = env("GA4_END_DATE", "yesterday")
-    # Merge key defaults to the dimension columns, so re-pulling a lookback window
-    # heals GA4's late-arriving data instead of duplicating or freezing it.
+    # Primary keys identify report rows. The date merge key replaces each returned
+    # date partition, so rows that disappear from a revised report do not remain.
     primary_key = [
         key.strip()
         for key in env("PRIMARY_KEY", ",".join(dimensions)).split(",")
         if key.strip()
     ]
+    if write_disposition == "merge" and "date" not in dimensions:
+        raise ValueError(
+            "GA4_DIMENSIONS must include date when WRITE_DISPOSITION=merge so each "
+            "refreshed date can be replaced. Use append or replace without date."
+        )
 
     # dlt writes working files under HOME; a Flight has a writable /tmp.
     os.environ.setdefault("HOME", "/tmp")
@@ -132,11 +155,15 @@ def main() -> None:
         destination="motherduck",
         dataset_name=dataset_name,
     )
-    load_info = pipeline.run(
+    report_rows = dlt.resource(
         ga4_rows(property_id, dimensions, metrics, start_date, end_date),
-        table_name=table_name,
+        name=table_name,
         write_disposition=write_disposition,
         primary_key=primary_key,
+        merge_key="date" if write_disposition == "merge" else None,
+    )
+    load_info = pipeline.run(
+        report_rows,
         # Prefer Parquet loader files over row-wise insert_values so larger
         # sources stay on a bulk-loading path. Keep this unless you have measured
         # a reason to change it.
@@ -168,6 +195,16 @@ def main() -> None:
 def env(name: str, default: str) -> str:
     value = os.environ.get(name, default).strip()
     return value or default
+
+
+def flight_secret_value(name: str) -> str:
+    if value := os.environ.get(name, "").strip():
+        return value
+    suffix = f"_{name}"
+    return next(
+        (value.strip() for key, value in os.environ.items() if key.endswith(suffix) and value.strip()),
+        "",
+    )
 
 
 def validate_identifier(name: str, value: str) -> str:

--- a/flight-plans/flight-dlt-ga4-ingest/requirements.txt
+++ b/flight-plans/flight-dlt-ga4-ingest/requirements.txt
@@ -1,0 +1,3 @@
+duckdb==1.5.2
+dlt[motherduck]==1.27.0
+google-analytics-data==0.23.0

--- a/flight-plans/flight-dlt-ga4-ingest/requirements.txt
+++ b/flight-plans/flight-dlt-ga4-ingest/requirements.txt
@@ -1,3 +1,3 @@
 duckdb==1.5.2
-dlt[motherduck]==1.27.0
+dlt[motherduck]==1.27.2
 google-analytics-data==0.23.0


### PR DESCRIPTION
## What

Adds a new Flight Plan template: **`flight-plans/flight-dlt-ga4-ingest`** — a single-file MotherDuck Flight that runs a [dlt](https://dlthub.com/docs/dlt-ecosystem/destinations/motherduck) pipeline pulling **Google Analytics 4 (GA4)** report data into MotherDuck on a schedule.

It is the GA4 adaptation of [`flight-dlt-ingest`](../flight-dlt-ingest): the demo `repo_rows()` source is swapped for a `ga4_rows()` source that calls the GA4 Data API (`runReport`), and the rest of the pattern — dlt-managed schema/evolution, Parquet loader files, a run ledger, and Flight scheduling — is unchanged. Everything is driven by Flight config, so you adapt it by setting config values, not by editing `flight.py`. Defaults pull the last 7 days of sessions/users/pageviews by default channel group into `ga4_ingest.ga4.ga4_report`.

## Highlights

- **Aggregated reports, not raw events.** The Data API returns pre-aggregated report rows (metrics by dimension), not event-level data. The README states this up front and points users who need raw GA4 events to the native GA4 → BigQuery export with [`flight-bigquery-ingest`](../flight-bigquery-ingest) instead.
- **Parquet loader files by default.** `loader_file_format="parquet"` keeps larger sources on a bulk-loading path rather than row-wise `insert_values`.
- **`merge` over a moving lookback window.** GA4 keeps revising recent days as attribution windows settle, so the default re-pulls `7daysAgo`→`yesterday` and merges on the dimension columns — a recent day's row gets *corrected* on later runs instead of frozen wrong (`append` would double-count, `replace` would discard history). The dimension list is the table grain and the default merge key.
- **No tokens in SQL or config.** dlt writes working files under `HOME=/tmp` (a Flight's writable dir), the MotherDuck destination is pointed at `DESTINATION_DATABASE` via env var, and service-account credentials come from the `GA4_SERVICE_ACCOUNT_JSON` Flights secret read from the environment — never from config.
- **Pages the GA4 cap.** `ga4_rows()` pages through results in 10k-row pages (the GA4 per-request limit) until the full `row_count` is read, and appends one row to the run ledger capturing the dlt load package summary.

## Files

- `flight-plans/flight-dlt-ga4-ingest/flight.py` — the Flight source
- `flight-plans/flight-dlt-ga4-ingest/requirements.txt` — `duckdb`, `dlt[motherduck]`, `google-analytics-data`
- `flight-plans/flight-dlt-ga4-ingest/README.md` — front matter + aggregated-vs-raw guidance, how-it-works, dlt setup rationale, adapt-the-pattern, caveats, security

## Validation

- `python3 -m py_compile flight.py` → compiles clean.
- Front matter conforms to the catalog schema: `type: template`, `category: ingestion`, `features: [flights]`, lowercase-slug `tags: [dlt, ingest]` (non-allowlisted ga4/google-analytics tags were dropped in 9f885e7).
- Note: `uv run scripts/build-catalog.py` was not run in this environment (`uv`/`pyyaml` unavailable locally) — recommend confirming the catalog check in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
