### PR TITLE
Document `max_runtime_sec` and new table function

### DIFF
--- a/flight-plans/flight-analysis-agent/README.md
+++ b/flight-plans/flight-analysis-agent/README.md
@@ -228,6 +228,7 @@ arguments to your situation), passing:
 - `name`: a Flight name, for example `analysis_agent`
 - `source_code`: the contents of [`flight.py`](flight.py)
 - `requirements_txt`: the contents of [`requirements.txt`](requirements.txt)
+- `max_runtime_sec`: optional cap on a run's duration in seconds (`0` = no cap)
 - `flight_secret_names`: `["openrouter"]` so the key is injected (as
   `openrouter_OPENROUTER_API_KEY`; `flight.py` resolves it)
 - `config` (optional): override `MODEL`, `CONCURRENCY`, `BRIEF_WINDOW_DAYS`,
@@ -238,7 +239,7 @@ time as `MOTHERDUCK_TOKEN`; no token argument is needed.
 
 Create the Flight without a schedule first, trigger one manual run with
 `MD_RUN_FLIGHT(flight_id := ...)` (the id is returned by `MD_CREATE_FLIGHT` and
-listed by `MD_FLIGHTS()`), and confirm it succeeds and briefs land in
+listed by `MD_FLIGHTS()`; inspect a specific run with `MD_GET_FLIGHT_RUN(flight_id := ..., run_number := ...)`), and confirm it succeeds and briefs land in
 `RESULTS_TABLE`. Keep `MAX_BOROUGHS` small for that first run to bound cost. Then
 clear the cap and add a schedule (for example `0 13 * * *`, daily at 13:00 UTC)
 by updating the Flight's `schedule_cron` with `MD_UPDATE_FLIGHT`. Schedule updates

--- a/flight-plans/flight-analysis-agent/README.md
+++ b/flight-plans/flight-analysis-agent/README.md
@@ -239,11 +239,13 @@ time as `MOTHERDUCK_TOKEN`; no token argument is needed.
 
 Create the Flight without a schedule first, trigger one manual run with
 `MD_RUN_FLIGHT(flight_id := ...)` (the id is returned by `MD_CREATE_FLIGHT` and
-listed by `MD_FLIGHTS()`; inspect a specific run with `MD_GET_FLIGHT_RUN(flight_id := ..., run_number := ...)`), and confirm it succeeds and briefs land in
-`RESULTS_TABLE`. Keep `MAX_BOROUGHS` small for that first run to bound cost. Then
-clear the cap and add a schedule (for example `0 13 * * *`, daily at 13:00 UTC)
-by updating the Flight's `schedule_cron` with `MD_UPDATE_FLIGHT`. Schedule updates
-are metadata-only and do not create a new Flight version.
+listed by `MD_FLIGHTS()`; inspect a specific run with
+`MD_GET_FLIGHT_RUN(flight_id := ..., run_number := ...)`), and confirm it
+succeeds and briefs land in `RESULTS_TABLE`. Keep `MAX_BOROUGHS` small for that
+first run to bound cost. Then clear the cap and add a schedule (for example `0
+13 * * *`, daily at 13:00 UTC) by updating the Flight's `schedule_cron` with
+`MD_UPDATE_FLIGHT`. Schedule updates are metadata-only and do not create a new
+Flight version.
 
 ## Building agents, briefly
 

--- a/flight-plans/flight-bigquery-ingest/README.md
+++ b/flight-plans/flight-bigquery-ingest/README.md
@@ -249,6 +249,7 @@ is checked in; adapt the arguments to your situation), passing:
 - `source_code`: the contents of [`flight.py`](flight.py), with the USER-EDIT
   BLOCKS edited to your read mode, source, and destination
 - `requirements_txt`: the contents of [`requirements.txt`](requirements.txt)
+- `max_runtime_sec`: optional cap on a run's duration in seconds (`0` = no cap)
 - `flight_secret_names`: `["gcp_creds"]` so the SA JSON is injected (as
   `gcp_creds_GOOGLE_APPLICATION_CREDENTIALS_JSON`; `flight.py` resolves it)
 - `config`: `GCP_PROJECT_ID` (and optionally `BIGQUERY_DEST_DB`, `EVENT_SOURCE`).
@@ -260,7 +261,7 @@ time as `MOTHERDUCK_TOKEN`; no token argument is needed.
 
 Create the Flight without a schedule first, trigger one manual run with
 `MD_RUN_FLIGHT(flight_id := ...)` (the id is returned by `MD_CREATE_FLIGHT` and
-listed by `MD_FLIGHTS()`), and confirm it loads the cold-start partition. Then
+listed by `MD_FLIGHTS()`; inspect a specific run with `MD_GET_FLIGHT_RUN(flight_id := ..., run_number := ...)`), and confirm it loads the cold-start partition. Then
 add a schedule (for example `0 6 * * *`, daily at 06:00 UTC) by updating the
 Flight's `schedule_cron` with `MD_UPDATE_FLIGHT`. Schedule updates are
 metadata-only and do not create a new Flight version. For a one-off backfill, set `start_dt`/`end_dt` (or `target_dt`)

--- a/flight-plans/flight-bigquery-ingest/README.md
+++ b/flight-plans/flight-bigquery-ingest/README.md
@@ -261,11 +261,12 @@ time as `MOTHERDUCK_TOKEN`; no token argument is needed.
 
 Create the Flight without a schedule first, trigger one manual run with
 `MD_RUN_FLIGHT(flight_id := ...)` (the id is returned by `MD_CREATE_FLIGHT` and
-listed by `MD_FLIGHTS()`; inspect a specific run with `MD_GET_FLIGHT_RUN(flight_id := ..., run_number := ...)`), and confirm it loads the cold-start partition. Then
-add a schedule (for example `0 6 * * *`, daily at 06:00 UTC) by updating the
-Flight's `schedule_cron` with `MD_UPDATE_FLIGHT`. Schedule updates are
-metadata-only and do not create a new Flight version. For a one-off backfill, set `start_dt`/`end_dt` (or `target_dt`)
-in the run config.
+listed by `MD_FLIGHTS()`; inspect a specific run with
+`MD_GET_FLIGHT_RUN(flight_id := ..., run_number := ...)`), and confirm it loads
+the cold-start partition. Then add a schedule (for example `0 6 * * *`, daily at
+06:00 UTC) by updating the Flight's `schedule_cron` with `MD_UPDATE_FLIGHT`.
+Schedule updates are metadata-only and do not create a new Flight version. For a
+one-off backfill, set `start_dt`/`end_dt` (or `target_dt`) in the run config.
 
 ## Security
 

--- a/flight-plans/flight-dive-usage-metrics/README.md
+++ b/flight-plans/flight-dive-usage-metrics/README.md
@@ -209,6 +209,7 @@ checked in; adapt the arguments to your situation), passing:
 - `name`: a Flight name, for example `dive_usage_metrics`
 - `source_code`: the contents of [`flight.py`](flight.py)
 - `requirements_txt`: the contents of [`requirements.txt`](requirements.txt)
+- `max_runtime_sec`: optional cap on a run's duration in seconds (`0` = no cap)
 - `config`: the keys from [What you'll adjust](#what-youll-adjust) you want to
   override (omit any you are keeping at default)
 
@@ -218,7 +219,7 @@ Dives that token can read, so deploy from an account that sees them.
 
 Create the Flight without a schedule, trigger one manual run with
 `MD_RUN_FLIGHT(flight_id := ...)` (the id is returned by `MD_CREATE_FLIGHT` and
-listed by `MD_FLIGHTS()`), and read the run logs and the `_latest` view to
+listed by `MD_FLIGHTS()`; inspect a specific run with `MD_GET_FLIGHT_RUN(flight_id := ..., run_number := ...)`), and read the run logs and the `_latest` view to
 confirm the metrics look right. Then add a schedule by updating the Flight's
 `schedule_cron` with `MD_UPDATE_FLIGHT`. A daily run
 (`0 6 * * *`) or weekly run (`0 6 * * 1`) is a reasonable cadence, since Dive

--- a/flight-plans/flight-dive-usage-metrics/README.md
+++ b/flight-plans/flight-dive-usage-metrics/README.md
@@ -219,12 +219,13 @@ Dives that token can read, so deploy from an account that sees them.
 
 Create the Flight without a schedule, trigger one manual run with
 `MD_RUN_FLIGHT(flight_id := ...)` (the id is returned by `MD_CREATE_FLIGHT` and
-listed by `MD_FLIGHTS()`; inspect a specific run with `MD_GET_FLIGHT_RUN(flight_id := ..., run_number := ...)`), and read the run logs and the `_latest` view to
-confirm the metrics look right. Then add a schedule by updating the Flight's
-`schedule_cron` with `MD_UPDATE_FLIGHT`. A daily run
-(`0 6 * * *`) or weekly run (`0 6 * * 1`) is a reasonable cadence, since Dive
-source SQL changes slowly. Schedule updates are metadata-only and do not create a
-new Flight version.
+listed by `MD_FLIGHTS()`; inspect a specific run with
+`MD_GET_FLIGHT_RUN(flight_id := ..., run_number := ...)`), and read the run logs
+and the `_latest` view to confirm the metrics look right. Then add a schedule by
+updating the Flight's `schedule_cron` with `MD_UPDATE_FLIGHT`. A daily run (`0 6
+* * *`) or weekly run (`0 6 * * 1`) is a reasonable cadence, since Dive source
+SQL changes slowly. Schedule updates are metadata-only and do not create a new
+Flight version.
 
 ## Security
 

--- a/flight-plans/flight-dlt-ingest/README.md
+++ b/flight-plans/flight-dlt-ingest/README.md
@@ -148,11 +148,12 @@ time as `MOTHERDUCK_TOKEN`; no token argument is needed.
 
 Create the Flight without a schedule first, trigger one manual run with
 `MD_RUN_FLIGHT(flight_id := ...)` (the id is returned by `MD_CREATE_FLIGHT` and
-listed by `MD_FLIGHTS()`; inspect a specific run with `MD_GET_FLIGHT_RUN(flight_id := ..., run_number := ...)`), and confirm it succeeds and the dlt tables and ledger
-row appear. Once the manual run is green, add a daily schedule (`15 7 * * *`,
-07:15 UTC, is a reasonable default) by updating the Flight's `schedule_cron` with
-`MD_UPDATE_FLIGHT`. Schedule updates are metadata-only and do not create a new
-Flight version.
+listed by `MD_FLIGHTS()`; inspect a specific run with
+`MD_GET_FLIGHT_RUN(flight_id := ..., run_number := ...)`), and confirm it
+succeeds and the dlt tables and ledger row appear. Once the manual run is green,
+add a daily schedule (`15 7 * * *`, 07:15 UTC, is a reasonable default) by
+updating the Flight's `schedule_cron` with `MD_UPDATE_FLIGHT`. Schedule updates
+are metadata-only and do not create a new Flight version.
 
 ## Security
 

--- a/flight-plans/flight-dlt-ingest/README.md
+++ b/flight-plans/flight-dlt-ingest/README.md
@@ -139,6 +139,7 @@ checked in; adapt the arguments to your situation), passing:
 - `name`: a Flight name, for example `dlt_ingest`
 - `source_code`: the contents of [`flight.py`](flight.py)
 - `requirements_txt`: the contents of [`requirements.txt`](requirements.txt)
+- `max_runtime_sec`: optional cap on a run's duration in seconds (`0` = no cap)
 - `config`: the keys from [What you'll adjust](#what-youll-adjust) you want to
   override (omit any you are keeping at default)
 
@@ -147,7 +148,7 @@ time as `MOTHERDUCK_TOKEN`; no token argument is needed.
 
 Create the Flight without a schedule first, trigger one manual run with
 `MD_RUN_FLIGHT(flight_id := ...)` (the id is returned by `MD_CREATE_FLIGHT` and
-listed by `MD_FLIGHTS()`), and confirm it succeeds and the dlt tables and ledger
+listed by `MD_FLIGHTS()`; inspect a specific run with `MD_GET_FLIGHT_RUN(flight_id := ..., run_number := ...)`), and confirm it succeeds and the dlt tables and ledger
 row appear. Once the manual run is green, add a daily schedule (`15 7 * * *`,
 07:15 UTC, is a reasonable default) by updating the Flight's `schedule_cron` with
 `MD_UPDATE_FLIGHT`. Schedule updates are metadata-only and do not create a new

--- a/flight-plans/flight-ducklake-maintenance/README.md
+++ b/flight-plans/flight-ducklake-maintenance/README.md
@@ -142,6 +142,7 @@ in; adapt the arguments to your situation), passing:
 - `name`: a Flight name, for example `ducklake_maintenance`
 - `source_code`: the contents of [`flight.py`](flight.py)
 - `requirements_txt`: the contents of [`requirements.txt`](requirements.txt)
+- `max_runtime_sec`: optional cap on a run's duration in seconds (`0` = no cap)
 - `config`: at least `DUCKLAKE_DATABASE`, plus any knobs from
   [What you'll adjust](#what-youll-adjust) you want to override (omit any you are
   keeping at default)
@@ -152,7 +153,7 @@ the target lake.
 
 Create the Flight without a schedule first, trigger one manual run with
 `MD_RUN_FLIGHT(flight_id := ...)` (the id is returned by `MD_CREATE_FLIGHT` and listed
-by `MD_FLIGHTS()`) — using a `config` override of `DRY_RUN := 'true'` for the first
+by `MD_FLIGHTS()`; inspect a specific run with `MD_GET_FLIGHT_RUN(flight_id := ..., run_number := ...)`) — using a `config` override of `DRY_RUN := 'true'` for the first
 run is a safe way to see what it will touch — and confirm the log looks right. Once a
 real run is green, add a schedule that matches your ingest cadence (a lake written all
 day might run `0 * * * *` hourly; a nightly batch might run `0 7 * * *`) by updating

--- a/flight-plans/flight-ducklake-maintenance/README.md
+++ b/flight-plans/flight-ducklake-maintenance/README.md
@@ -152,12 +152,14 @@ as `MOTHERDUCK_TOKEN`; no token argument is needed. Give that token write access
 the target lake.
 
 Create the Flight without a schedule first, trigger one manual run with
-`MD_RUN_FLIGHT(flight_id := ...)` (the id is returned by `MD_CREATE_FLIGHT` and listed
-by `MD_FLIGHTS()`; inspect a specific run with `MD_GET_FLIGHT_RUN(flight_id := ..., run_number := ...)`) — using a `config` override of `DRY_RUN := 'true'` for the first
-run is a safe way to see what it will touch — and confirm the log looks right. Once a
-real run is green, add a schedule that matches your ingest cadence (a lake written all
-day might run `0 * * * *` hourly; a nightly batch might run `0 7 * * *`) by updating
-the Flight's `schedule_cron` with `MD_UPDATE_FLIGHT`. 
+`MD_RUN_FLIGHT(flight_id := ...)` (the id is returned by `MD_CREATE_FLIGHT` and
+listed by `MD_FLIGHTS()`; inspect a specific run with
+`MD_GET_FLIGHT_RUN(flight_id := ..., run_number := ...)`) — using a `config`
+override of `DRY_RUN := 'true'` for the first run is a safe way to see what it
+will touch — and confirm the log looks right. Once a real run is green, add a
+schedule that matches your ingest cadence (a lake written all day might run `0 *
+* * *` hourly; a nightly batch might run `0 7 * * *`) by updating the Flight's
+`schedule_cron` with `MD_UPDATE_FLIGHT`.
 
 ## Security
 

--- a/flight-plans/flight-excel-s3-ingest/README.md
+++ b/flight-plans/flight-excel-s3-ingest/README.md
@@ -129,6 +129,7 @@ checked in; adapt the arguments to your situation), passing:
 - `name`: a Flight name, for example `excel_s3_ingest`
 - `source_code`: the contents of [`flight.py`](https://github.com/motherduckdb/motherduck-cookbook/blob/main/flight-plans/flight-excel-s3-ingest/flight.py)
 - `requirements_txt`: the contents of [`requirements.txt`](https://github.com/motherduckdb/motherduck-cookbook/blob/main/flight-plans/flight-excel-s3-ingest/requirements.txt)
+- `max_runtime_sec`: optional cap on a run's duration in seconds (`0` = no cap)
 - `config`: the keys from [What you'll adjust](#what-youll-adjust) you want to
   override (omit any you are keeping at default)
 
@@ -137,7 +138,7 @@ time as `MOTHERDUCK_TOKEN`; no token argument is needed.
 
 Create the Flight without a schedule first, trigger one manual run with
 `MD_RUN_FLIGHT(flight_id := ...)` (the id is returned by `MD_CREATE_FLIGHT` and
-listed by `MD_FLIGHTS()`), and confirm it succeeds. Once the manual run is green,
+listed by `MD_FLIGHTS()`; inspect a specific run with `MD_GET_FLIGHT_RUN(flight_id := ..., run_number := ...)`), and confirm it succeeds. Once the manual run is green,
 add a schedule that matches how often the workbook is republished (for example
 `0 7 * * *`, 07:00 UTC daily) by updating the Flight's `schedule_cron` with
 `MD_UPDATE_FLIGHT`. Schedule updates are metadata-only and do not create a new

--- a/flight-plans/flight-excel-s3-ingest/README.md
+++ b/flight-plans/flight-excel-s3-ingest/README.md
@@ -138,11 +138,12 @@ time as `MOTHERDUCK_TOKEN`; no token argument is needed.
 
 Create the Flight without a schedule first, trigger one manual run with
 `MD_RUN_FLIGHT(flight_id := ...)` (the id is returned by `MD_CREATE_FLIGHT` and
-listed by `MD_FLIGHTS()`; inspect a specific run with `MD_GET_FLIGHT_RUN(flight_id := ..., run_number := ...)`), and confirm it succeeds. Once the manual run is green,
-add a schedule that matches how often the workbook is republished (for example
-`0 7 * * *`, 07:00 UTC daily) by updating the Flight's `schedule_cron` with
-`MD_UPDATE_FLIGHT`. Schedule updates are metadata-only and do not create a new
-Flight version.
+listed by `MD_FLIGHTS()`; inspect a specific run with
+`MD_GET_FLIGHT_RUN(flight_id := ..., run_number := ...)`), and confirm it
+succeeds. Once the manual run is green, add a schedule that matches how often
+the workbook is republished (for example `0 7 * * *`, 07:00 UTC daily) by
+updating the Flight's `schedule_cron` with `MD_UPDATE_FLIGHT`. Schedule updates
+are metadata-only and do not create a new Flight version.
 
 ## Security
 

--- a/flight-plans/flight-freshness-alert/README.md
+++ b/flight-plans/flight-freshness-alert/README.md
@@ -209,11 +209,12 @@ attached to the Flight automatically and injected at run time as
 
 Create the Flight without a schedule first, trigger one manual run with
 `MD_RUN_FLIGHT(flight_id := ...)` (the id is returned by `MD_CREATE_FLIGHT` and
-listed by `MD_FLIGHTS()`; inspect a specific run with `MD_GET_FLIGHT_RUN(flight_id := ..., run_number := ...)`), and confirm it succeeds and a Slack alert arrives.
-Then edit `CHECKS` to your real tables and add a schedule (for example
-`0 * * * *`, hourly) by updating the Flight's `schedule_cron` with
-`MD_UPDATE_FLIGHT`. Schedule updates are metadata-only and do not create a new
-Flight version.
+listed by `MD_FLIGHTS()`; inspect a specific run with
+`MD_GET_FLIGHT_RUN(flight_id := ..., run_number := ...)`), and confirm it
+succeeds and a Slack alert arrives. Then edit `CHECKS` to your real tables and
+add a schedule (for example `0 * * * *`, hourly) by updating the Flight's
+`schedule_cron` with `MD_UPDATE_FLIGHT`. Schedule updates are metadata-only and
+do not create a new Flight version.
 
 ## Security
 

--- a/flight-plans/flight-freshness-alert/README.md
+++ b/flight-plans/flight-freshness-alert/README.md
@@ -199,6 +199,7 @@ is checked in; adapt the arguments to your situation), passing:
 - `name`: a Flight name, for example `freshness_alert`
 - `source_code`: the contents of [`flight.py`](flight.py), with `CHECKS` edited to your tables
 - `requirements_txt`: the contents of [`requirements.txt`](requirements.txt)
+- `max_runtime_sec`: optional cap on a run's duration in seconds (`0` = no cap)
 - `flight_secret_names`: `["freshness_slack"]` so the webhook is injected (as
   `freshness_slack_SLACK_WEBHOOK_URL`; `flight.py` resolves it)
 
@@ -208,7 +209,7 @@ attached to the Flight automatically and injected at run time as
 
 Create the Flight without a schedule first, trigger one manual run with
 `MD_RUN_FLIGHT(flight_id := ...)` (the id is returned by `MD_CREATE_FLIGHT` and
-listed by `MD_FLIGHTS()`), and confirm it succeeds and a Slack alert arrives.
+listed by `MD_FLIGHTS()`; inspect a specific run with `MD_GET_FLIGHT_RUN(flight_id := ..., run_number := ...)`), and confirm it succeeds and a Slack alert arrives.
 Then edit `CHECKS` to your real tables and add a schedule (for example
 `0 * * * *`, hourly) by updating the Flight's `schedule_cron` with
 `MD_UPDATE_FLIGHT`. Schedule updates are metadata-only and do not create a new

--- a/flight-plans/flight-google-sheets/README.md
+++ b/flight-plans/flight-google-sheets/README.md
@@ -173,6 +173,7 @@ checked in; adapt the arguments to your situation), passing:
 - `name`: a Flight name, for example `google_sheets_sync`
 - `source_code`: [`flight.py`](flight.py) (no edits for the common cases)
 - `requirements_txt`: [`requirements.txt`](requirements.txt)
+- `max_runtime_sec`: optional cap on a run's duration in seconds (`0` = no cap)
 - `flight_secret_names`: `["gsheets"]` so the service-account key is injected
 - `config`: your `SOURCE_SHEETS` and/or `EXPORTS` JSON, plus `TARGET_DATABASE`/`TARGET_SCHEMA` if non-default. Credentials stay in the `gsheets` secret, never config.
 
@@ -180,7 +181,7 @@ A MotherDuck token is attached to the Flight automatically and injected at run
 time as `MOTHERDUCK_TOKEN`; no token argument is needed.
 
 Create without a schedule, run once with `MD_RUN_FLIGHT(flight_id := ...)` (the
-id is returned by `MD_CREATE_FLIGHT` and listed by `MD_FLIGHTS()`), and confirm
+id is returned by `MD_CREATE_FLIGHT` and listed by `MD_FLIGHTS()`; inspect a specific run with `MD_GET_FLIGHT_RUN(flight_id := ..., run_number := ...)`), and confirm
 `<TARGET_DATABASE>.main.gsheets_sync_log` has one row per item. Decide with the
 user whether a schedule is desired and what cadence fits the data.
 

--- a/flight-plans/flight-google-sheets/README.md
+++ b/flight-plans/flight-google-sheets/README.md
@@ -181,9 +181,10 @@ A MotherDuck token is attached to the Flight automatically and injected at run
 time as `MOTHERDUCK_TOKEN`; no token argument is needed.
 
 Create without a schedule, run once with `MD_RUN_FLIGHT(flight_id := ...)` (the
-id is returned by `MD_CREATE_FLIGHT` and listed by `MD_FLIGHTS()`; inspect a specific run with `MD_GET_FLIGHT_RUN(flight_id := ..., run_number := ...)`), and confirm
-`<TARGET_DATABASE>.main.gsheets_sync_log` has one row per item. Decide with the
-user whether a schedule is desired and what cadence fits the data.
+id is returned by `MD_CREATE_FLIGHT` and listed by `MD_FLIGHTS()`; inspect a
+specific run with `MD_GET_FLIGHT_RUN(flight_id := ..., run_number := ...)`), and
+confirm `<TARGET_DATABASE>.main.gsheets_sync_log` has one row per item. Decide
+with the user whether a schedule is desired and what cadence fits the data.
 
 ## Security
 

--- a/flight-plans/flight-hubspot-list-sync/README.md
+++ b/flight-plans/flight-hubspot-list-sync/README.md
@@ -167,9 +167,10 @@ A MotherDuck token is attached to the Flight automatically and injected at run
 time as `MOTHERDUCK_TOKEN`; no token argument is needed.
 
 Create without a schedule, run once with `MD_RUN_FLIGHT(flight_id := ...)` (the
-id is returned by `MD_CREATE_FLIGHT` and listed by `MD_FLIGHTS()`; inspect a specific run with `MD_GET_FLIGHT_RUN(flight_id := ..., run_number := ...)`), and confirm
-the list membership matches the query and `AUDIT_TABLE` has a new row. Decide a
-schedule with the user before adding one.
+id is returned by `MD_CREATE_FLIGHT` and listed by `MD_FLIGHTS()`; inspect a
+specific run with `MD_GET_FLIGHT_RUN(flight_id := ..., run_number := ...)`), and
+confirm the list membership matches the query and `AUDIT_TABLE` has a new row.
+Decide a schedule with the user before adding one.
 
 ## Security
 

--- a/flight-plans/flight-hubspot-list-sync/README.md
+++ b/flight-plans/flight-hubspot-list-sync/README.md
@@ -158,6 +158,7 @@ checked in; adapt the arguments), passing:
 - `name`: a Flight name, for example `hubspot-list-sync`
 - `source_code`: [`flight.py`](flight.py)
 - `requirements_txt`: [`requirements.txt`](requirements.txt)
+- `max_runtime_sec`: optional cap on a run's duration in seconds (`0` = no cap)
 - `flight_secret_names`: `["hubspot"]` so `HUBSPOT_ACCESS_TOKEN` is injected
 - `config`: at least `QUERY` and `HUBSPOT_LIST_ID`, plus any other knobs above.
   The token stays in the `hubspot` secret, never in config.
@@ -166,7 +167,7 @@ A MotherDuck token is attached to the Flight automatically and injected at run
 time as `MOTHERDUCK_TOKEN`; no token argument is needed.
 
 Create without a schedule, run once with `MD_RUN_FLIGHT(flight_id := ...)` (the
-id is returned by `MD_CREATE_FLIGHT` and listed by `MD_FLIGHTS()`), and confirm
+id is returned by `MD_CREATE_FLIGHT` and listed by `MD_FLIGHTS()`; inspect a specific run with `MD_GET_FLIGHT_RUN(flight_id := ..., run_number := ...)`), and confirm
 the list membership matches the query and `AUDIT_TABLE` has a new row. Decide a
 schedule with the user before adding one.
 

--- a/flight-plans/flight-postgres-ingest/README.md
+++ b/flight-plans/flight-postgres-ingest/README.md
@@ -177,9 +177,11 @@ A MotherDuck token is attached to the Flight automatically and injected at run
 time as `MOTHERDUCK_TOKEN`; no token argument is needed.
 
 Create without a schedule, run once with `MD_RUN_FLIGHT(flight_id := ...)` (the
-id is returned by `MD_CREATE_FLIGHT` and listed by `MD_FLIGHTS()`; inspect a specific run with `MD_GET_FLIGHT_RUN(flight_id := ..., run_number := ...)`), and confirm
-`<TARGET_DATABASE>.main.flight_tracker` has one row per table. 
-Get feedback from the user about whether or not a schedule is desired and what it should be.
+id is returned by `MD_CREATE_FLIGHT` and listed by `MD_FLIGHTS()`; inspect a
+specific run with `MD_GET_FLIGHT_RUN(flight_id := ..., run_number := ...)`), and
+confirm `<TARGET_DATABASE>.main.flight_tracker` has one row per table. Get
+feedback from the user about whether or not a schedule is desired and what it
+should be.
 
 ## Security
 

--- a/flight-plans/flight-postgres-ingest/README.md
+++ b/flight-plans/flight-postgres-ingest/README.md
@@ -169,6 +169,7 @@ is checked in; adapt the arguments to your situation), passing:
 - `name`: a Flight name, for example `postgres_ingest`
 - `source_code`: [`flight.py`](flight.py) (no edits for the default "mirror everything non-system")
 - `requirements_txt`: [`requirements.txt`](requirements.txt)
+- `max_runtime_sec`: optional cap on a run's duration in seconds (`0` = no cap)
 - `flight_secret_names`: `["pg"]` so the Postgres connection is injected
 - `config`: at least `TARGET_DATABASE`, plus any `INCLUDED_*`/`EXCLUDED_*` scoping and `MOTHERDUCK_HOST` if non-default. The connection stays in the `pg` secret, never config.
 
@@ -176,7 +177,7 @@ A MotherDuck token is attached to the Flight automatically and injected at run
 time as `MOTHERDUCK_TOKEN`; no token argument is needed.
 
 Create without a schedule, run once with `MD_RUN_FLIGHT(flight_id := ...)` (the
-id is returned by `MD_CREATE_FLIGHT` and listed by `MD_FLIGHTS()`), and confirm
+id is returned by `MD_CREATE_FLIGHT` and listed by `MD_FLIGHTS()`; inspect a specific run with `MD_GET_FLIGHT_RUN(flight_id := ..., run_number := ...)`), and confirm
 `<TARGET_DATABASE>.main.flight_tracker` has one row per table. 
 Get feedback from the user about whether or not a schedule is desired and what it should be.
 

--- a/flight-plans/flight-provision-user-databases/README.md
+++ b/flight-plans/flight-provision-user-databases/README.md
@@ -136,12 +136,14 @@ databases and shares, so deploy it from an account allowed to do both.
 
 Create the Flight without a schedule, trigger one manual run with
 `MD_RUN_FLIGHT(flight_id := ...)` (the id is returned by `MD_CREATE_FLIGHT` and
-listed by `MD_FLIGHTS()`; inspect a specific run with `MD_GET_FLIGHT_RUN(flight_id := ..., run_number := ...)`) while `DRY_RUN` is `true`, and read the ledger and run
-logs to confirm the plan. Then point `USERS_TABLE` at real usernames (or replace
-the seeded demo rows), set `DRY_RUN=false`, and run again to provision. Add a
-schedule by updating the Flight's `schedule_cron` with `MD_UPDATE_FLIGHT` only
-once you trust the control table; schedule updates are metadata-only and do not
-create a new Flight version.
+listed by `MD_FLIGHTS()`; inspect a specific run with
+`MD_GET_FLIGHT_RUN(flight_id := ..., run_number := ...)`) while `DRY_RUN` is
+`true`, and read the ledger and run logs to confirm the plan. Then point
+`USERS_TABLE` at real usernames (or replace the seeded demo rows), set
+`DRY_RUN=false`, and run again to provision. Add a schedule by updating the
+Flight's `schedule_cron` with `MD_UPDATE_FLIGHT` only once you trust the control
+table; schedule updates are metadata-only and do not create a new Flight
+version.
 
 ## Security
 

--- a/flight-plans/flight-provision-user-databases/README.md
+++ b/flight-plans/flight-provision-user-databases/README.md
@@ -126,6 +126,7 @@ checked in; adapt the arguments to your situation), passing:
 - `name`: a Flight name, for example `provision_user_databases`
 - `source_code`: the contents of [`flight.py`](flight.py)
 - `requirements_txt`: the contents of [`requirements.txt`](requirements.txt)
+- `max_runtime_sec`: optional cap on a run's duration in seconds (`0` = no cap)
 - `config`: the keys from [What you'll adjust](#what-youll-adjust) you want to
   override (omit any you are keeping at default)
 
@@ -135,7 +136,7 @@ databases and shares, so deploy it from an account allowed to do both.
 
 Create the Flight without a schedule, trigger one manual run with
 `MD_RUN_FLIGHT(flight_id := ...)` (the id is returned by `MD_CREATE_FLIGHT` and
-listed by `MD_FLIGHTS()`) while `DRY_RUN` is `true`, and read the ledger and run
+listed by `MD_FLIGHTS()`; inspect a specific run with `MD_GET_FLIGHT_RUN(flight_id := ..., run_number := ...)`) while `DRY_RUN` is `true`, and read the ledger and run
 logs to confirm the plan. Then point `USERS_TABLE` at real usernames (or replace
 the seeded demo rows), set `DRY_RUN=false`, and run again to provision. Add a
 schedule by updating the Flight's `schedule_cron` with `MD_UPDATE_FLIGHT` only

--- a/flight-plans/flight-s3tables-iceberg-ingest/README.md
+++ b/flight-plans/flight-s3tables-iceberg-ingest/README.md
@@ -97,11 +97,13 @@ non-zero if any table failed after retries.
 ### Deploy as a Flight
 
 Create it with `MD_CREATE_FLIGHT`, passing `name`, `source_code` ([`flight.py`](flight.py)),
-`requirements_txt` ([`requirements.txt`](requirements.txt)), and a `config` with at least
-`TABLE_BUCKET_ARN` plus any `INCLUDED_*`/`EXCLUDED_*` scoping and `TARGET_DATABASE`. No secret
-arguments are needed: the Flight reads a stored `IN MOTHERDUCK` secret, and a MotherDuck token is
-attached for you. Run it once with `MD_RUN_FLIGHT`, confirm `flight_tracker` has one row per table,
-then add a schedule with `MD_UPDATE_FLIGHT`. Use long-lived IAM keys for scheduled runs.
+`requirements_txt` ([`requirements.txt`](requirements.txt)), optionally `max_runtime_sec` (cap on a
+run's duration in seconds; `0` = no cap), and a `config` with at least `TABLE_BUCKET_ARN` plus any
+`INCLUDED_*`/`EXCLUDED_*` scoping and `TARGET_DATABASE`. No secret arguments are needed: the Flight
+reads a stored `IN MOTHERDUCK` secret, and a MotherDuck token is attached for you. Run it once with
+`MD_RUN_FLIGHT`, confirm `flight_tracker` has one row per table (inspect the run with
+`MD_GET_FLIGHT_RUN(flight_id := ..., run_number := ...)`), then add a schedule with
+`MD_UPDATE_FLIGHT`. Use long-lived IAM keys for scheduled runs.
 
 ## Caveats
 

--- a/flight-plans/flight-scheduled-s3-ingest/README.md
+++ b/flight-plans/flight-scheduled-s3-ingest/README.md
@@ -126,6 +126,7 @@ checked in; adapt the arguments to your situation), passing:
 - `name`: a Flight name, for example `scheduled_s3_ingest`
 - `source_code`: the contents of [`flight.py`](flight.py)
 - `requirements_txt`: the contents of [`requirements.txt`](requirements.txt)
+- `max_runtime_sec`: optional cap on a run's duration in seconds (`0` = no cap)
 - `config`: the keys from [What you'll adjust](#what-youll-adjust) you want to
   override (omit any you are keeping at default)
 
@@ -134,7 +135,7 @@ time as `MOTHERDUCK_TOKEN`; no token argument is needed.
 
 Create the Flight without a schedule first, trigger one manual run with
 `MD_RUN_FLIGHT(flight_id := ...)` (the id is returned by `MD_CREATE_FLIGHT` and
-listed by `MD_FLIGHTS()`), and confirm it succeeds. Each run reads only
+listed by `MD_FLIGHTS()`; inspect a specific run with `MD_GET_FLIGHT_RUN(flight_id := ..., run_number := ...)`), and confirm it succeeds. Each run reads only
 `LOAD_PARTITION`, so the live partition stays fresh without touching the
 historical files. Once the manual run is green, add a daily schedule (the source
 updates daily; `30 6 * * *`, 06:30 UTC, is a reasonable default) by updating the

--- a/flight-plans/flight-scheduled-s3-ingest/README.md
+++ b/flight-plans/flight-scheduled-s3-ingest/README.md
@@ -135,12 +135,14 @@ time as `MOTHERDUCK_TOKEN`; no token argument is needed.
 
 Create the Flight without a schedule first, trigger one manual run with
 `MD_RUN_FLIGHT(flight_id := ...)` (the id is returned by `MD_CREATE_FLIGHT` and
-listed by `MD_FLIGHTS()`; inspect a specific run with `MD_GET_FLIGHT_RUN(flight_id := ..., run_number := ...)`), and confirm it succeeds. Each run reads only
-`LOAD_PARTITION`, so the live partition stays fresh without touching the
-historical files. Once the manual run is green, add a daily schedule (the source
-updates daily; `30 6 * * *`, 06:30 UTC, is a reasonable default) by updating the
-Flight's `schedule_cron` with `MD_UPDATE_FLIGHT`. Schedule updates are
-metadata-only and do not create a new Flight version.
+listed by `MD_FLIGHTS()`; inspect a specific run with
+`MD_GET_FLIGHT_RUN(flight_id := ..., run_number := ...)`), and confirm it
+succeeds. Each run reads only `LOAD_PARTITION`, so the live partition stays
+fresh without touching the historical files. Once the manual run is green, add a
+daily schedule (the source updates daily; `30 6 * * *`, 06:30 UTC, is a
+reasonable default) by updating the Flight's `schedule_cron` with
+`MD_UPDATE_FLIGHT`. Schedule updates are metadata-only and do not create a new
+Flight version.
 
 ## Security
 

--- a/flight-plans/flight-snowflake-ingest/README.md
+++ b/flight-plans/flight-snowflake-ingest/README.md
@@ -215,6 +215,7 @@ is checked in; adapt the arguments to your situation), passing:
 - `name`: a Flight name, for example `snowflake_ingest`
 - `source_code`: the contents of [`flight.py`](flight.py)
 - `requirements_txt`: the contents of [`requirements.txt`](requirements.txt)
+- `max_runtime_sec`: optional cap on a run's duration in seconds (`0` = no cap)
 - `config`: the non-secret knobs, for example
   `{"MODE": "discover", "SNOWFLAKE_ACCOUNT": "ab12345.eu-west-1", "SNOWFLAKE_WAREHOUSE": "your_wh", "SNOWFLAKE_DATABASE": "SOURCE_DB", "TARGET_DB": "flights_demo", "DRY_RUN": "true"}`
 - `flight_secret_names`: `["snowflake_creds"]` so the user and password are
@@ -226,7 +227,7 @@ time as `MOTHERDUCK_TOKEN`; no token argument is needed.
 
 Create the Flight with `MODE=discover`, trigger one manual run with
 `MD_RUN_FLIGHT(flight_id := ...)` (the id is returned by `MD_CREATE_FLIGHT` and
-listed by `MD_FLIGHTS()`), and confirm the inventory lands in MotherDuck. Curate `selected`, then run
+listed by `MD_FLIGHTS()`; inspect a specific run with `MD_GET_FLIGHT_RUN(flight_id := ..., run_number := ...)`), and confirm the inventory lands in MotherDuck. Curate `selected`, then run
 `MODE=move` with `DRY_RUN=false` (a config change, not a new Flight version) to
 copy. Schedule it only if you want a recurring refresh.
 

--- a/flight-plans/flight-snowflake-ingest/README.md
+++ b/flight-plans/flight-snowflake-ingest/README.md
@@ -227,9 +227,11 @@ time as `MOTHERDUCK_TOKEN`; no token argument is needed.
 
 Create the Flight with `MODE=discover`, trigger one manual run with
 `MD_RUN_FLIGHT(flight_id := ...)` (the id is returned by `MD_CREATE_FLIGHT` and
-listed by `MD_FLIGHTS()`; inspect a specific run with `MD_GET_FLIGHT_RUN(flight_id := ..., run_number := ...)`), and confirm the inventory lands in MotherDuck. Curate `selected`, then run
-`MODE=move` with `DRY_RUN=false` (a config change, not a new Flight version) to
-copy. Schedule it only if you want a recurring refresh.
+listed by `MD_FLIGHTS()`; inspect a specific run with
+`MD_GET_FLIGHT_RUN(flight_id := ..., run_number := ...)`), and confirm the
+inventory lands in MotherDuck. Curate `selected`, then run `MODE=move` with
+`DRY_RUN=false` (a config change, not a new Flight version) to copy. Schedule it
+only if you want a recurring refresh.
 
 ## Security
 

--- a/flight-plans/flight-sql-transformation/README.md
+++ b/flight-plans/flight-sql-transformation/README.md
@@ -94,12 +94,14 @@ Deploy through the Flight SQL surface (`MD_CREATE_FLIGHT`, then
 
 - `source_code`: [`flight.py`](flight.py), with `sql_statements()` edited to your statements
 - `requirements_txt`: [`requirements.txt`](requirements.txt)
+- `max_runtime_sec`: optional cap on a run's duration in seconds (`0` = no cap)
 - `config`: `TARGET_DATABASE`, `MAX_WORKERS` as needed
 
 The Flight runtime injects `MOTHERDUCK_TOKEN`; make sure it can write the
 destination database. Create the Flight without a schedule, trigger one run with
-`MD_RUN_FLIGHT` to confirm it loads, then add a `schedule_cron` using cron
-syntax based on user input.
+`MD_RUN_FLIGHT` to confirm it loads (inspect the run with
+`MD_GET_FLIGHT_RUN(flight_id := ..., run_number := ...)`), then add a
+`schedule_cron` using cron syntax based on user input.
 
 ## Learn more
 


### PR DESCRIPTION
Every deploy section now lists the optional `max_runtime_sec` for `MD_CREATE_FLIGHT`, and the run-once instructions point at `MD_GET_FLIGHT_RUN(flight_id, run_number)` for inspecting a specific run without paging `MD_LIST_FLIGHT_RUNS`. 