### PR TITLE
Read flight secrets under their bare parameter names

### DIFF
--- a/flight-plans/flight-analysis-agent/README.md
+++ b/flight-plans/flight-analysis-agent/README.md
@@ -215,12 +215,10 @@ CREATE SECRET openrouter IN motherduck (
 );
 ```
 
-A `TYPE flights` secret injects each param under the env var
-`<secret_name>_<PARAM>`, not the bare param name: the param above arrives as
-`openrouter_OPENROUTER_API_KEY`, not `OPENROUTER_API_KEY`. (DuckDB lowercases the
-unquoted secret name into the prefix.) `flight.py` handles this: it reads
-`OPENROUTER_API_KEY` for local runs and otherwise picks up any env var ending in
-`_OPENROUTER_API_KEY`, so the secret name you choose does not matter.
+A `TYPE flights` secret injects each param under its bare name, so the param
+above arrives as `OPENROUTER_API_KEY` whatever you name the secret. (Each param
+is also injected namespaced as `<secret_name>_<PARAM>`, which disambiguates
+when several secrets define the same param name.)
 
 Then create the Flight with the `MD_CREATE_FLIGHT` SQL function (adapt the
 arguments to your situation), passing:

--- a/flight-plans/flight-analysis-agent/flight.py
+++ b/flight-plans/flight-analysis-agent/flight.py
@@ -69,19 +69,13 @@ def resolve_openrouter_key() -> str:
     """Return the OpenRouter API key.
 
     A local run sets OPENROUTER_API_KEY directly. Deployed as a Flight, the key
-    comes from a `TYPE flights` secret, which MotherDuck injects under the env
-    var `<secret_name>_<PARAM>`, not the bare param name. So a secret named
-    `openrouter` with an OPENROUTER_API_KEY param arrives as
-    `openrouter_OPENROUTER_API_KEY`. Accept the exact name first (local), then
-    any var ending in the suffix (the secret, whatever you named it).
+    comes from a `TYPE flights` secret whose params MotherDuck injects under
+    their bare names (plus a namespaced `<secret_name>_<PARAM>` variant to
+    disambiguate same-named params across secrets), so one lookup covers both.
     """
     key = os.environ.get("OPENROUTER_API_KEY", "").strip()
     if key:
         return key
-    for name, value in os.environ.items():
-        if name.endswith("_OPENROUTER_API_KEY") and value.strip():
-            log(f"Using OPENROUTER_API_KEY from secret env var {name!r}")
-            return value.strip()
     raise SystemExit(
         "OPENROUTER_API_KEY is required (set it locally or add a Flights secret)."
     )

--- a/flight-plans/flight-bigquery-ingest/README.md
+++ b/flight-plans/flight-bigquery-ingest/README.md
@@ -183,7 +183,7 @@ GCP billing project, and the service-account credentials.
 | `build_filters()` | top of `flight.py` | `start_dt`, `end_dt`, `event_source` | Returns the `{placeholder}` values for `SCAN_FILTER`/`QUERY` and `MD_DELETE_PREDICATE`. Reads per-run overrides (e.g. `EVENT_SOURCE`) from the environment. |
 | `GCP_PROJECT_ID` | Flight config / env var | (required) | The GCP billing project charged for the read. In scan mode it is interpolated into `bigquery_scan` (named args can't be bound); in query mode it is bound as a parameter. Validated as a project id. |
 | `GOOGLE_APPLICATION_CREDENTIALS` | env var (local) | (unset) | Path to a service-account JSON file on disk. Used for a local run. |
-| `GOOGLE_APPLICATION_CREDENTIALS_JSON` | Flight secret | (unset) | The service-account JSON itself, provided through a `TYPE flights` secret. Deployed, it arrives as `<secret_name>_GOOGLE_APPLICATION_CREDENTIALS_JSON`; `flight.py` resolves either name. |
+| `GOOGLE_APPLICATION_CREDENTIALS_JSON` | Flight secret | (unset) | The service-account JSON itself, provided through a `TYPE flights` secret. |
 | `start_dt` / `end_dt` / `target_dt` | env var (optional) | (unset) | Override the window: explicit inclusive backfill range, or a single day. Unset = watermark mode. |
 | `BIGQUERY_DEST_DB` | Flight config / env var (optional) | `DEFAULT_DB` | Override the destination database without editing code. |
 | `MOTHERDUCK_TOKEN` | Flight-injected | (Flight-injected) | Auth. Select a token on the Flight; never hard-code it. |
@@ -232,15 +232,12 @@ CREATE SECRET gcp_creds IN motherduck (
 );
 ```
 
-A `TYPE flights` secret injects each param under the env var
-`<secret_name>_<PARAM>`, not the bare param name: the param above arrives as
-`gcp_creds_GOOGLE_APPLICATION_CREDENTIALS_JSON`, not
-`GOOGLE_APPLICATION_CREDENTIALS_JSON`. (DuckDB lowercases the unquoted secret name
-into the prefix.) `flight.py` handles this: it reads the bare
-`GOOGLE_APPLICATION_CREDENTIALS_JSON` for local runs and otherwise picks up any
-env var ending in `_GOOGLE_APPLICATION_CREDENTIALS_JSON`, then writes the JSON to
-a temp file and points `GOOGLE_APPLICATION_CREDENTIALS` at it. The secret name you
-choose does not matter.
+A `TYPE flights` secret injects each param under its bare name, so the param
+above arrives as `GOOGLE_APPLICATION_CREDENTIALS_JSON` whatever you name the
+secret. (Each param is also injected namespaced as `<secret_name>_<PARAM>`,
+which disambiguates when several secrets define the same param name.)
+`flight.py` writes the JSON to a temp file and points
+`GOOGLE_APPLICATION_CREDENTIALS` at it.
 
 Then create the Flight with the `MD_CREATE_FLIGHT` SQL function (no deploy SQL
 is checked in; adapt the arguments to your situation), passing:

--- a/flight-plans/flight-bigquery-ingest/flight.py
+++ b/flight-plans/flight-bigquery-ingest/flight.py
@@ -310,7 +310,7 @@ def _materialize_gcp_creds() -> None:
       - Deployed Flight: the SA JSON is a secret, so it must NOT travel in
         plaintext Flight config. It is stored as a MotherDuck `TYPE flights`
         secret with a GOOGLE_APPLICATION_CREDENTIALS_JSON param, which the
-        runtime injects as the env var `<secret_name>_GOOGLE_APPLICATION_CREDENTIALS_JSON`.
+        runtime injects under that bare name whatever the secret is called.
         We read that JSON blob, validate it parses, write it to a private temp
         file, and set GOOGLE_APPLICATION_CREDENTIALS to that path.
     """
@@ -345,21 +345,12 @@ def _materialize_gcp_creds() -> None:
 def resolve_creds_json() -> str:
     """Find the SA JSON blob in the environment.
 
-    Mirrors flight-freshness-alert's resolve_webhook(): a local run sets the
-    bare GOOGLE_APPLICATION_CREDENTIALS_JSON; deployed, a TYPE flights secret
-    injects it under `<secret_name>_GOOGLE_APPLICATION_CREDENTIALS_JSON`, where
-    the secret name (whatever you call it) becomes a lowercased prefix. Accept
-    the exact name first, then any env var ending in the suffix, so the secret
-    name does not matter.
+    A local run sets GOOGLE_APPLICATION_CREDENTIALS_JSON directly; deployed, a
+    TYPE flights secret injects its params under their bare names (plus a
+    namespaced `<secret_name>_<PARAM>` variant to disambiguate same-named
+    params across secrets), so one lookup covers both.
     """
-    direct = os.environ.get(CREDS_JSON_ENV, "").strip()
-    if direct:
-        return direct
-    suffix = f"_{CREDS_JSON_ENV}"
-    for key, value in os.environ.items():
-        if key.endswith(suffix) and value.strip():
-            return value.strip()
-    return ""
+    return os.environ.get(CREDS_JSON_ENV, "").strip()
 
 
 def _connect_duckdb() -> duckdb.DuckDBPyConnection:

--- a/flight-plans/flight-freshness-alert/README.md
+++ b/flight-plans/flight-freshness-alert/README.md
@@ -116,7 +116,7 @@ and the MotherDuck token come from outside the code.
 | `warn_after_hours` / `error_after_hours` | `CHECKS` entry | `24` / `48` | Age thresholds in hours. `lag >= error` → `error`, `>= warn` → `warn`, else `pass`. |
 | `ALERT_LEVEL` | top of `flight.py` | `warn` | `warn` alerts on warn+error; `error` alerts only on error. |
 | `RESULTS_TABLE` | top of `flight.py` | `flights_demo.main.freshness_check_runs` | Audit ledger target as `database.schema.table`. Must be a writable database. `""` disables the ledger. |
-| `SLACK_WEBHOOK_URL` | Flight secret / env var | (unset) | Slack Incoming Webhook URL. Provide it through a MotherDuck secret, never in code. As a Flight the secret arrives as `<secret_name>_SLACK_WEBHOOK_URL`; `flight.py` resolves either name. Unset → the run prints the report and skips Slack. |
+| `SLACK_WEBHOOK_URL` | Flight secret / env var | (unset) | Slack Incoming Webhook URL. Provide it through a MotherDuck secret, never in code. Unset → the run prints the report and skips Slack. |
 | `MOTHERDUCK_TOKEN` | Flight-injected | (Flight-injected) | Auth. Select a token on the Flight; never hard-code it. |
 
 ## Run it
@@ -186,12 +186,10 @@ CREATE SECRET freshness_slack IN motherduck (
 );
 ```
 
-A `TYPE flights` secret injects each param under the env var
-`<secret_name>_<PARAM>`, not the bare param name: the param above arrives as
-`freshness_slack_SLACK_WEBHOOK_URL`, not `SLACK_WEBHOOK_URL`. (DuckDB lowercases
-the unquoted secret name into the prefix.) `flight.py` handles this: it reads
-`SLACK_WEBHOOK_URL` for local runs and otherwise picks up any env var ending in
-`_SLACK_WEBHOOK_URL`, so the secret name you choose does not matter.
+A `TYPE flights` secret injects each param under its bare name, so the param
+above arrives as `SLACK_WEBHOOK_URL` whatever you name the secret. (Each param
+is also injected namespaced as `<secret_name>_<PARAM>`, which disambiguates
+when several secrets define the same param name.)
 
 Then create the Flight with the `MD_CREATE_FLIGHT` SQL function (no deploy SQL
 is checked in; adapt the arguments to your situation), passing:

--- a/flight-plans/flight-freshness-alert/flight.py
+++ b/flight-plans/flight-freshness-alert/flight.py
@@ -84,19 +84,11 @@ def main() -> None:
 
 def resolve_webhook() -> str:
     # A local run sets SLACK_WEBHOOK_URL directly (see "Run it"). Deployed as a
-    # Flight, the webhook comes from a `TYPE flights` secret, and MotherDuck
-    # injects each secret param under the env var `<secret_name>_<PARAM>`, NOT
-    # the bare param name. So a secret named `freshness_slack` with a
-    # `SLACK_WEBHOOK_URL` param arrives as `freshness_slack_SLACK_WEBHOOK_URL`.
-    # Accept both: the exact name first (local), then any var ending in the
-    # suffix (the secret, whatever you named it).
-    direct = os.environ.get("SLACK_WEBHOOK_URL", "").strip()
-    if direct:
-        return direct
-    for key, value in os.environ.items():
-        if key.endswith("_SLACK_WEBHOOK_URL") and value.strip():
-            return value.strip()
-    return ""
+    # Flight, the webhook comes from a `TYPE flights` secret whose params
+    # MotherDuck injects under their bare names (plus a namespaced
+    # `<secret_name>_<PARAM>` variant to disambiguate same-named params across
+    # secrets), so the same lookup covers both.
+    return os.environ.get("SLACK_WEBHOOK_URL", "").strip()
 
 
 def evaluate(con: duckdb.DuckDBPyConnection, check: dict) -> dict:

--- a/flight-plans/flight-google-sheets/README.md
+++ b/flight-plans/flight-google-sheets/README.md
@@ -106,11 +106,10 @@ MotherDuck **Flights secret** holding the Google service-account key.
 | `EXPORTS` | `[]` | JSON array of queries to publish. Each: `{"url"}` plus EITHER `query` (one SELECT) OR `database`+`table` (optional `schema`, `limit`); optional `sheet`, `create_sheet`. Leave blank for import-only. |
 | `TARGET_DATABASE` | `google_sheets` | MotherDuck database imported tables land in (created if absent). Also holds the `gsheets_sync_log` audit table. |
 | `TARGET_SCHEMA` | `main` | Schema imported tables land in. |
-| `GSHEETS_SECRET_NAME` | `gsheets` | Name of the `TYPE flights` secret holding `SERVICE_ACCOUNT_JSON`. |
 | `MAX_RETRIES` | `5` | Per-item retry attempts. |
 | `RETRY_BASE_SECONDS` | `2` | Exponential-backoff multiplier (seconds). |
 | `MOTHERDUCK_HOST` | (unset) | Override MotherDuck host (non-prod). Leave unset for default. |
-| `gsheets` **secret** | (required) | `TYPE flights` secret with one param, `SERVICE_ACCOUNT_JSON`, holding the full service-account key JSON. |
+| `gsheets` **secret** | (required) | `TYPE flights` secret (any name) with one param, `SERVICE_ACCOUNT_JSON`, holding the full service-account key JSON. Its params arrive under their bare names. |
 
 Example config values:
 
@@ -138,8 +137,8 @@ For a local run, inject the key the same way the Flights secret would:
 
 ```bash
 export MOTHERDUCK_TOKEN=your_token_here
-# the service-account key JSON, exactly as the `gsheets` Flights secret injects it:
-export gsheets_SERVICE_ACCOUNT_JSON="$(cat path/to/service-account.json)"
+# the service-account key JSON, exactly as a Flights secret injects it:
+export SERVICE_ACCOUNT_JSON="$(cat path/to/service-account.json)"
 # pick a direction (either, or both):
 export SOURCE_SHEETS='[{"url":"https://docs.google.com/spreadsheets/d/<id>/edit","table":"target_accounts"}]'
 export EXPORTS='[{"url":"https://docs.google.com/spreadsheets/d/<id>/edit","sheet":"calls_today","create_sheet":true,"query":"SELECT 1 AS demo"}]'

--- a/flight-plans/flight-google-sheets/flight.py
+++ b/flight-plans/flight-google-sheets/flight.py
@@ -15,8 +15,8 @@ Each import and export is retried on errors.
 Success or failure is logged in an audit log in <target>.main.gsheets_sync_log.
 
 Config (env vars):
-    Secret `GSHEETS_SECRET_NAME` (default gsheets) injects
-    `<name>_SERVICE_ACCOUNT_JSON`: a Google service-account key (never expires;
+    A flights secret (any name) with a SERVICE_ACCOUNT_JSON param injects
+    `SERVICE_ACCOUNT_JSON`: a Google service-account key (never expires;
     the extension mints short-lived OAuth tokens from it). Share each sheet with
     its client_email (Viewer for sources, Editor for destinations).
     TARGET_DATABASE - import destination database (default google_sheets)
@@ -304,15 +304,15 @@ def build_copy_sql(spec: SheetExport, source_sql: str) -> str:
 
 
 # ---- Connections + auth ----
-def validate_service_account_json(secret_name: str) -> tuple[str, str]:
+def validate_service_account_json() -> tuple[str, str]:
     """Pre-flight credential check, run BEFORE any connection so a missing/garbled
     secret exits 2 with a clean error. Returns (client_email, private_key)."""
-    env_var = f"{secret_name}_SERVICE_ACCOUNT_JSON"
+    env_var = "SERVICE_ACCOUNT_JSON"
     sa_json = os.environ.get(env_var)
     if not sa_json:
         raise RuntimeError(
-            f"Env var {env_var} is not set. Provide a `{secret_name}` flights secret "
-            "with a SERVICE_ACCOUNT_JSON param holding a Google service-account key."
+            f"Env var {env_var} is not set. Provide a flights secret with a "
+            "SERVICE_ACCOUNT_JSON param holding a Google service-account key."
         )
     try:
         parsed = json.loads(sa_json)
@@ -405,11 +405,11 @@ def run_export(
     return f"{spec.url} (sheet={spec.sheet or '<first>'})", arrow_tbl.num_rows
 
 
-def setup_connections(secret_name: str, target_db: str) -> tuple:
+def setup_connections(target_db: str) -> tuple:
     """Validate credentials, open both connections, register gsheet auth, and ensure
     the audit table. Raises on any failure so main() can exit 2 (nothing attempted).
     Returns (md, local, client_email)."""
-    client_email, private_key = validate_service_account_json(secret_name)
+    client_email, private_key = validate_service_account_json()
     md = duckdb.connect("md:")
     local = duckdb.connect()  # sheet writes only: COPY (FORMAT gsheet) is
     # unresolvable on any connection with the motherduck extension loaded.
@@ -430,7 +430,6 @@ def main() -> None:
     # `or default` so a blank env var falls back to the default, not an empty string.
     TARGET_DB = os.environ.get("TARGET_DATABASE") or "google_sheets"
     TARGET_SCHEMA = os.environ.get("TARGET_SCHEMA") or "main"
-    SECRET_NAME = os.environ.get("GSHEETS_SECRET_NAME") or "gsheets"
 
     # ValueError (bad MAX_RETRIES/RETRY_BASE_SECONDS) is config-class -> exit 2, not a
     # runtime traceback; ConfigError subclasses ValueError, so one except covers both.
@@ -451,7 +450,7 @@ def main() -> None:
         return
 
     try:
-        md, local, client_email = setup_connections(SECRET_NAME, TARGET_DB)
+        md, local, client_email = setup_connections(TARGET_DB)
     except Exception as exc:  # noqa: BLE001 - setup failure = nothing attempted = exit 2
         log.error("Setup failed before any item was attempted: %s", exc)
         sys.exit(2)

--- a/flight-plans/flight-hubspot-list-sync/README.md
+++ b/flight-plans/flight-hubspot-list-sync/README.md
@@ -103,10 +103,11 @@ credential, so it must be a secret, never config).
 | `RETRY_BASE_SECONDS` | `2` | Exponential-backoff multiplier (seconds). |
 | `DRY_RUN` | `false` | `true` computes and logs the diff without changing the list. |
 | `AUDIT_TABLE` | `hubspot_list_sync.main.flight_tracker` | Ledger table (created if absent); `""` to skip. |
-| `hubspot` **secret** | (required) | `TYPE flights` secret with param `ACCESS_TOKEN` (Service Key or private app token). |
+| `hubspot` **secret** | (required) | `TYPE flights` secret with param `HUBSPOT_ACCESS_TOKEN` (Service Key or private app token). |
 
-The secret injects its param as `HUBSPOT_ACCESS_TOKEN`. The Flight reads that at
-runtime; for a local run you can instead export `HUBSPOT_PRIVATE_APP_TOKEN`.
+Flight secret params are injected under their bare names, so the param arrives
+as `HUBSPOT_ACCESS_TOKEN` whatever the secret is called. The Flight reads that
+at runtime; for a local run you can instead export `HUBSPOT_PRIVATE_APP_TOKEN`.
 
 ## Run it
 
@@ -131,13 +132,13 @@ it to `false`) to apply the diff and write an audit row.
 
 First store the HubSpot token as a **Flights secret** named `hubspot` (UI:
 [Settings > Secrets](https://app.motherduck.com/settings/secrets), type
-**Flights**, param `ACCESS_TOKEN`). Or via SQL from a write-enabled connection
-(read-only connections reject `CREATE SECRET`):
+**Flights**, param `HUBSPOT_ACCESS_TOKEN`). Or via SQL from a write-enabled
+connection (read-only connections reject `CREATE SECRET`):
 
 ```sql
 CREATE SECRET hubspot IN motherduck (
   TYPE flights,
-  PARAMS MAP { 'ACCESS_TOKEN': 'your_service_key_or_pat' }
+  PARAMS MAP { 'HUBSPOT_ACCESS_TOKEN': 'your_service_key_or_pat' }
 );
 ```
 
@@ -148,7 +149,7 @@ client-side there:
 ```sql
 CREATE SECRET hubspot IN motherduck (
   TYPE flights,
-  PARAMS MAP { 'ACCESS_TOKEN': getenv('HUBSPOT_PRIVATE_APP_TOKEN') }
+  PARAMS MAP { 'HUBSPOT_ACCESS_TOKEN': getenv('HUBSPOT_PRIVATE_APP_TOKEN') }
 );
 ```
 

--- a/flight-plans/flight-hubspot-list-sync/flight.py
+++ b/flight-plans/flight-hubspot-list-sync/flight.py
@@ -76,22 +76,17 @@ class RetryableHTTPError(Exception):
 # Config / helpers
 # --------------------------------------------------------------------------- #
 def resolve_token() -> str:
-    """Find the HubSpot token without ever logging it. Accepts the deployed
-    secret env var (HUBSPOT_ACCESS_TOKEN), the common local name
-    (HUBSPOT_PRIVATE_APP_TOKEN), or any '*_ACCESS_TOKEN' / '*_PRIVATE_APP_TOKEN'
-    secret-injected var (excluding MOTHERDUCK_TOKEN)."""
+    """Find the HubSpot token without ever logging it. Flight secret params are
+    injected under their bare names (plus a namespaced `<secret_name>_<PARAM>`
+    variant to disambiguate same-named params across secrets), so the deployed
+    secret and a local env var both arrive under the same name."""
     for name in ("HUBSPOT_ACCESS_TOKEN", "HUBSPOT_PRIVATE_APP_TOKEN"):
         val = os.environ.get(name, "").strip()
         if val:
             return val
-    for key, value in os.environ.items():
-        if key == "MOTHERDUCK_TOKEN":
-            continue
-        if (key.endswith("_ACCESS_TOKEN") or key.endswith("_PRIVATE_APP_TOKEN")) and value.strip():
-            return value.strip()
     raise RuntimeError(
-        "No HubSpot token found. Set HUBSPOT_ACCESS_TOKEN (local) or attach the "
-        "'hubspot' flight secret with an ACCESS_TOKEN param."
+        "No HubSpot token found. Set HUBSPOT_ACCESS_TOKEN locally or attach a "
+        "flight secret with a HUBSPOT_ACCESS_TOKEN param."
     )
 
 

--- a/flight-plans/flight-postgres-ingest/README.md
+++ b/flight-plans/flight-postgres-ingest/README.md
@@ -86,9 +86,8 @@ and use a different Flight template or modify this one heavily.
 
 No code edits are required (code edits are optional). 
 Everything is read from Flight config/env and a MotherDuck flights secret. 
-The MotherDuck **Flights secret** named `pg` contains the Postgres connection information
-which includes a password, so it must be in a secret. If a different secret name is desired, 
-update the SECRET_NAME variable in the code.
+The MotherDuck **Flights secret** (any name) contains the Postgres connection
+information, which includes a password, so it must be in a secret.
 
 | Knob | Default | Purpose |
 |---|---|---|
@@ -100,7 +99,7 @@ update the SECRET_NAME variable in the code.
 | `MAX_RETRIES` | `5` | Per-table retry attempts on transient errors. |
 | `RETRY_BASE_SECONDS` | `2` | Exponential-backoff multiplier (seconds). |
 | `MOTHERDUCK_HOST` | (unset) | Override MotherDuck host (e.g. non-prod). Leave unset for default. |
-| `pg` **secret** | (required) | Postgres connection. `TYPE flights` secret named `pg` with params `HOST`, `PORT`, `DATABASE`, `USER`, `PASSWORD`, `SSLMODE`. |
+| `pg` **secret** | (required) | Postgres connection. `TYPE flights` secret (any name) with params `PGHOST`, `PGPORT`, `PGDATABASE`, `PGUSER`, `PGPASSWORD`, `PGSSLMODE`. |
 
 Selection precedence: a table is mirrored only if its schema passes the schema
 gate **and** its `schema.table` passes the table gate; excludes are `AND NOT` at
@@ -108,27 +107,29 @@ every level, so exclude always wins (including a table whose schema is excluded)
 System schemas (`information_schema`, `pg_catalog`, `pg_toast`, `pg_temp*`) are
 always excluded.
 
-Two gotchas with the `pg` secret:
-- **KEYS must be UPPERCASE.** The secret injects each param as `pg_<KEY>` (e.g.
-  `pg_HOST`), which `flight.py` reads via `PG_PARAMS`.
-- **Code edits are required to use a name other than `pg`.** DuckDB lowercases the secret name into the prefix.
-  Rename the secret only if you also change `SECRET_NAME` in `flight.py`.
+The secret's params are the libpq env vars themselves (`PGHOST`, `PGPASSWORD`,
+...): a flights secret injects each param under its bare name, so libpq picks
+them up with no mapping and the secret name is yours to choose. A legacy secret
+named `pg` with `HOST`/`PORT`/... params (injected namespaced as `pg_HOST`,
+`pg_PORT`, ...) keeps working. Existing `flight_tracker` ledgers: the
+`flight_secret_name` column is now `source_host` — rename it with
+`ALTER TABLE ... RENAME COLUMN`, or drop the ledger to recreate it.
 
 ## Run it
 
 You need a MotherDuck account and token, plus a reachable Postgres source. For a
-local run, set the same `pg_*` names the secret would inject (no credential-free
+local run, set the same libpq names the secret would inject (no credential-free
 smoke test — a reachable Postgres is required).
 
 ```bash
 export MOTHERDUCK_TOKEN=your_token_here
-# Postgres connection (same names the `pg` Flights secret injects):
-export pg_HOST=your-postgres-host
-export pg_PORT=5432
-export pg_DATABASE=your_database
-export pg_USER=readonly_user
-export pg_PASSWORD=your_password
-export pg_SSLMODE=require
+# Postgres connection (same names the Flights secret injects):
+export PGHOST=your-postgres-host
+export PGPORT=5432
+export PGDATABASE=your_database
+export PGUSER=readonly_user
+export PGPASSWORD=your_password
+export PGSSLMODE=require
 # optional: narrow scope / pick a destination
 # export TARGET_DATABASE=postgres_ingest
 # export INCLUDED_SCHEMAS=public
@@ -153,12 +154,12 @@ reject `CREATE SECRET`):
 CREATE SECRET pg IN motherduck (
   TYPE flights,
   PARAMS MAP {
-    'HOST': 'your-postgres-host',
-    'PORT': '5432',
-    'DATABASE': 'your_database',
-    'USER': 'readonly_user',
-    'PASSWORD': 'your_password',
-    'SSLMODE': 'require'
+    'PGHOST': 'your-postgres-host',
+    'PGPORT': '5432',
+    'PGDATABASE': 'your_database',
+    'PGUSER': 'readonly_user',
+    'PGPASSWORD': 'your_password',
+    'PGSSLMODE': 'require'
   }
 );
 ```

--- a/flight-plans/flight-postgres-ingest/flight.py
+++ b/flight-plans/flight-postgres-ingest/flight.py
@@ -17,21 +17,23 @@ Inputs
 ------
 Note that inputs are case sensitive (use uppercase).
 
-Secret `pg` (TYPE flights) -> Postgres connection params: 
-    Required: `HOST`, `DATABASE`, `USER`, `PASSWORD`
-    Optional: `PORT`, `SSLMODE`
+Secret (TYPE flights, any name) -> Postgres connection params, named as the
+libpq env vars so the injected bare params are libpq-ready as-is:
+    Required: `PGHOST`, `PGDATABASE`, `PGUSER`, `PGPASSWORD`
+    Optional: `PGPORT`, `PGSSLMODE`
     Example:
         CREATE SECRET pg IN motherduck (
             TYPE flights,
             PARAMS MAP {
-                'HOST':     '<your-postgres-host>',
-                'PORT':     '5432',
-                'DATABASE': '<your_database>',
-                'USER':     '<YOUR_USER>',
-                'PASSWORD': '<YOUR_PASSWORD>',
-                'SSLMODE':  'require'
+                'PGHOST':     '<your-postgres-host>',
+                'PGPORT':     '5432',
+                'PGDATABASE': '<your_database>',
+                'PGUSER':     '<YOUR_USER>',
+                'PGPASSWORD': '<YOUR_PASSWORD>',
+                'PGSSLMODE':  'require'
             }
         );
+    (A legacy secret named `pg` with HOST/PORT/... params still works.)
 Config (non-secret env vars):
     MOTHERDUCK_HOST  - staging host; exported as `motherduck_host` before connect.
     TARGET_DATABASE  - MotherDuck database to write into (default: postgres_ingest).
@@ -67,15 +69,16 @@ log = logging.getLogger("pg2md")
 # PostgreSQL system schemas that are never mirrored. 
 SYSTEM_SCHEMAS = {"information_schema", "pg_catalog", "pg_toast"}
 
-# Postgres connection params from the flight secret. 
-# The secret injects each as `<secret_name>_<KEY>`
+# Postgres connection params from the flight secret. Params named as libpq vars
+# (PGHOST, ...) arrive bare and are libpq-ready; a legacy secret named `pg` with
+# HOST/PORT/... params arrives namespaced as pg_HOST, pg_PORT, ...
 PG_PARAMS = (
-    ("HOST", "PGHOST", None, True),
-    ("PORT", "PGPORT", "5432", False),
-    ("DATABASE", "PGDATABASE", None, True),
-    ("USER", "PGUSER", None, True),
-    ("PASSWORD", "PGPASSWORD", None, True),
-    ("SSLMODE", "PGSSLMODE", "prefer", False),
+    ("PGHOST", "pg_HOST", None, True),
+    ("PGPORT", "pg_PORT", "5432", False),
+    ("PGDATABASE", "pg_DATABASE", None, True),
+    ("PGUSER", "pg_USER", None, True),
+    ("PGPASSWORD", "pg_PASSWORD", None, True),
+    ("PGSSLMODE", "pg_SSLMODE", "prefer", False),
 )
 
 # Local DuckDB catalog name the source Postgres database is ATTACHed as. Referenced by
@@ -143,16 +146,15 @@ def connect_motherduck() -> duckdb.DuckDBPyConnection:
     return duckdb.connect("md:")
 
 
-def attach_postgres(con: duckdb.DuckDBPyConnection, secret_name: str) -> None:
+def attach_postgres(con: duckdb.DuckDBPyConnection) -> None:
     """Wire up the read-only Postgres source so tables can be streamed out, keeping the
-    password out of SQL by passing credentials through libpq env vars. 
+    password out of SQL by passing credentials through libpq env vars.
     ATTACHes READ_ONLY as `pg`."""
-    for key, libpq_var, default, required in PG_PARAMS:
-        env_var = f"{secret_name}_{key}"
-        value = os.environ.get(env_var, default)
+    for libpq_var, legacy_var, default, required in PG_PARAMS:
+        value = os.environ.get(libpq_var) or os.environ.get(legacy_var) or default
         if value is None:
             if required:
-                raise RuntimeError(f"Required Postgres secret env var {env_var!r} is not set")
+                raise RuntimeError(f"Required Postgres secret param {libpq_var!r} is not set")
             continue
         os.environ[libpq_var] = str(value)
 
@@ -173,7 +175,7 @@ def ensure_target(con: duckdb.DuckDBPyConnection, target_db: str) -> None:
     con.execute(
         f"CREATE TABLE IF NOT EXISTS {target}.main.flight_tracker ("
         "  run_id               VARCHAR,"
-        "  flight_secret_name   VARCHAR,"
+        "  source_host          VARCHAR,"
         "  source_schema        VARCHAR,"
         "  source_table         VARCHAR,"
         "  destination_database VARCHAR,"
@@ -211,7 +213,7 @@ def load_table(con: duckdb.DuckDBPyConnection, target_db: str, schema: str, tabl
 
 
 def record_success(
-    con: duckdb.DuckDBPyConnection, target_db: str, run_id: str, secret_name: str,
+    con: duckdb.DuckDBPyConnection, target_db: str, run_id: str,
     schema: str, table: str, rows_loaded: int, attempts: int,
     started_at: datetime, finished_at: datetime, update_ts: datetime,
 ) -> None:
@@ -219,7 +221,7 @@ def record_success(
     con.execute(
         f"INSERT INTO {quote_ident(target_db)}.main.flight_tracker "
         "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
-        [run_id, secret_name, schema, table, target_db, schema, table,
+        [run_id, os.environ.get("PGHOST", ""), schema, table, target_db, schema, table,
          rows_loaded, attempts, started_at, finished_at, update_ts],
     )
 
@@ -239,14 +241,11 @@ def main() -> None:
     EXCLUDED_SCHEMAS = csv_set("EXCLUDED_SCHEMAS")
     INCLUDED_TABLES = csv_set("INCLUDED_TABLES")
     EXCLUDED_TABLES = csv_set("EXCLUDED_TABLES")
-    # MotherDuck Flights secret holding the Postgres connection; its params arrive as
-    # <SECRET_NAME>_HOST, <SECRET_NAME>_PORT, ... Change it to point at another secret.
-    SECRET_NAME = "pg"
 
     log.info("Run %s -> target %r", RUN_ID, TARGET_DB)
 
     con = connect_motherduck()
-    attach_postgres(con, SECRET_NAME)
+    attach_postgres(con)
     ensure_target(con, TARGET_DB)
 
     all_tables = discover_base_tables(con)
@@ -281,7 +280,7 @@ def main() -> None:
             rows = retryer(load_table, con, TARGET_DB, schema, table)
             attempts = retryer.statistics.get("attempt_number", 1)
             finished = datetime.now(timezone.utc)
-            record_success(con, TARGET_DB, RUN_ID, SECRET_NAME, schema, table, rows,
+            record_success(con, TARGET_DB, RUN_ID, schema, table, rows,
                            attempts, started, finished, datetime.now(timezone.utc))
             succeeded += 1
             rows_total += rows

--- a/flight-plans/flight-snowflake-ingest/README.md
+++ b/flight-plans/flight-snowflake-ingest/README.md
@@ -128,7 +128,7 @@ plain config.
 |---|---|---|---|
 | `MODE` | config / env | `all` | Which phase to run: `discover`, `move`, or `all`. |
 | `SNOWFLAKE_ACCOUNT` | config / env | (required) | Snowflake account identifier, for example `ab12345.eu-west-1`. |
-| `SNOWFLAKE_USER` | config / env or Flight secret | (required) | Snowflake login user. Can sit in plain config, or alongside the password in a Flights secret (arrives as `<secret_name>_SNOWFLAKE_USER`); `flight.py` resolves either. |
+| `SNOWFLAKE_USER` | config / env or Flight secret | (required) | Snowflake login user. Can sit in plain config, or alongside the password in a Flights secret; either way it arrives as `SNOWFLAKE_USER`. |
 | `SNOWFLAKE_WAREHOUSE` | config / env | (unset) | Warehouse for the discovery and move queries. Effectively required: querying `INFORMATION_SCHEMA.TABLES` needs an active warehouse, so without one discovery finds 0 tables. (`SHOW DATABASES` itself does not need a warehouse.) |
 | `SNOWFLAKE_ROLE` | config / env | (unset) | Role to assume. Optional. |
 | `SNOWFLAKE_DATABASE` | config / env | (unset) | Source database to scan. Leave it unset to scan every database the connection can see (enumerated with `SHOW TERSE DATABASES`), or set it to scope to one database. Validated as a SQL identifier when set. |
@@ -140,7 +140,7 @@ plain config.
 | `LEDGER_TABLE` | config / env | `snowflake_move_runs` | Per-table move ledger name. |
 | `MAX_ROWS_PER_TABLE` | config / env | `0` | Optional `LIMIT` per table during move (`0` means no cap). Useful for a sampled first pass. |
 | `DRY_RUN` | config / env | `true` | When true, MOVE logs the plan and writes ledger rows without copying data. Set `false` to copy for real. |
-| `SNOWFLAKE_PASSWORD` | Flight secret / env var | (required) | The Snowflake credential. Add it through a MotherDuck Flights secret (in the UI, see below), never in code or config. As a Flight the secret arrives as `<secret_name>_SNOWFLAKE_PASSWORD`; `flight.py` resolves either name. |
+| `SNOWFLAKE_PASSWORD` | Flight secret / env var | (required) | The Snowflake credential. Add it through a MotherDuck Flights secret (in the UI, see below), never in code or config. |
 | `MOTHERDUCK_TOKEN` | Flight-injected | (Flight-injected) | Auth for MotherDuck. Select a token on the Flight; never hard-code it. |
 
 ## Run it
@@ -201,13 +201,10 @@ CREATE SECRET snowflake_creds IN motherduck (
 );
 ```
 
-A `TYPE flights` secret injects each param under the env var
-`<secret_name>_<PARAM>`, not the bare param name: the params above arrive as
-`snowflake_creds_SNOWFLAKE_USER` and `snowflake_creds_SNOWFLAKE_PASSWORD`. (DuckDB
-lowercases the unquoted secret name into the prefix.) `flight.py` handles this: it
-reads the bare `SNOWFLAKE_USER` / `SNOWFLAKE_PASSWORD` for local runs and otherwise
-picks up any env var ending in `_SNOWFLAKE_USER` / `_SNOWFLAKE_PASSWORD`, so the
-secret name you choose does not matter.
+A `TYPE flights` secret injects each param under its bare name, so the params
+above arrive as `SNOWFLAKE_USER` and `SNOWFLAKE_PASSWORD` whatever you name the
+secret. (Each param is also injected namespaced as `<secret_name>_<PARAM>`,
+which disambiguates when several secrets define the same param name.)
 
 Then create the Flight with the `MD_CREATE_FLIGHT` SQL function (no deploy SQL
 is checked in; adapt the arguments to your situation), passing:

--- a/flight-plans/flight-snowflake-ingest/flight.py
+++ b/flight-plans/flight-snowflake-ingest/flight.py
@@ -15,8 +15,8 @@ DEFAULT_TARGET_DB = "flights_demo"
 def main() -> None:
     # Every knob is read from Flight config/env, so you adapt this template by
     # setting config values rather than editing code. The Snowflake user and
-    # password are the exception: they come from a MotherDuck secret (see
-    # resolve_secret_param).
+    # password are the exception: they come from a MotherDuck secret, whose
+    # params arrive under their bare names.
     mode = env("MODE", "all").strip().lower()
     if mode not in {"discover", "move", "all"}:
         raise ValueError(f"MODE must be 'discover', 'move', or 'all', got {mode!r}")
@@ -241,23 +241,24 @@ def record_move(
 
 def snowflake_connect_kwargs(source_database: str, source_schema: str) -> dict:
     # Non-secret connection params come from config/env; the user and password come
-    # from a MotherDuck secret (see resolve_secret_param). account and user are required.
+    # from a MotherDuck secret. account and user are required.
     account = env("SNOWFLAKE_ACCOUNT", "")
-    # user and password can both live in one TYPE flights secret, so resolve each
-    # from the bare env var (local) or the secret-injected `<secret_name>_<PARAM>`
-    # form (deployed). account is not a credential, so it stays in plain config.
-    user = resolve_secret_param("SNOWFLAKE_USER")
+    # user and password can both live in one TYPE flights secret; its params are
+    # injected under their bare names, so config, a local env var, and a deployed
+    # secret all arrive the same way. account is not a credential, so it stays in
+    # plain config.
+    user = env("SNOWFLAKE_USER", "")
     if not account or not user:
         raise ValueError(
             "SNOWFLAKE_ACCOUNT (config) and SNOWFLAKE_USER (config or a TYPE flights "
             "secret param) are both required"
         )
 
-    password = resolve_secret_param("SNOWFLAKE_PASSWORD")
+    password = env("SNOWFLAKE_PASSWORD", "")
     if not password:
         raise ValueError(
             "No Snowflake password found. Set SNOWFLAKE_PASSWORD locally, or deploy "
-            "a TYPE flights secret whose param arrives as <secret_name>_SNOWFLAKE_PASSWORD."
+            "a TYPE flights secret with a SNOWFLAKE_PASSWORD param."
         )
 
     kwargs: dict = {
@@ -278,27 +279,6 @@ def snowflake_connect_kwargs(source_database: str, source_schema: str) -> dict:
     if source_schema:
         kwargs["schema"] = source_schema
     return kwargs
-
-
-def resolve_secret_param(param: str) -> str:
-    # Resolve a connection param that may come from a MotherDuck `TYPE flights`
-    # secret. A local run can set the bare env var (e.g. SNOWFLAKE_PASSWORD).
-    # Deployed as a Flight, the secret injects each param under the env var
-    # `<secret_name>_<PARAM>`, NOT the bare name: the (lowercased) secret name
-    # becomes a prefix, so a secret `snowflake_migration_test` with a
-    # SNOWFLAKE_PASSWORD param arrives as
-    # `snowflake_migration_test_SNOWFLAKE_PASSWORD`. Accept both: the exact name
-    # first (local), then any var ending in `_<PARAM>` (the secret, whatever you
-    # named it). Both SNOWFLAKE_USER and SNOWFLAKE_PASSWORD can be stored this way.
-    # Mirrors resolve_webhook() in flight-freshness-alert.
-    direct = os.environ.get(param, "").strip()
-    if direct:
-        return direct
-    suffix = f"_{param}"
-    for key, value in os.environ.items():
-        if key.endswith(suffix) and value.strip():
-            return value.strip()
-    return ""
 
 
 def fetch_inventory_rows(sf_conn_kwargs: dict, source_database: str, source_schema: str) -> list:


### PR DESCRIPTION
Since a few releases, the runtime injects each flights-secret param under its bare, non-namespaced name as well as the namespaced `<secret_name>_<PARAM>` form. This PR drops the suffix-related logic and the 'must be named X' secret-name coupling across the flight plans: postgres-ingest for example now takes libpq-named params (PGHOST, ...) that are connection-ready as injected, with the legacy pg-named secret still supported.