### PR TITLE
Add a Shopify ingest Flight Plan

### DIFF
--- a/flight-plans/flight-shopify-ingest/README.md
+++ b/flight-plans/flight-shopify-ingest/README.md
@@ -1,0 +1,245 @@
+---
+title: Ingest Shopify Orders and Products as a Flight
+id: flight-shopify-ingest
+description: >-
+  A reusable Flight that loads Shopify orders, customers, and products into
+  MotherDuck on a schedule with dlt's Shopify source, minting a short-lived Admin
+  API token from Dev Dashboard client credentials on every run. Use when you want
+  scheduled Shopify ingestion without storing a long-lived token.
+type: template
+category: ingestion
+features: [flights]
+tags: [dlt, shopify, ingest]
+prompt: >-
+  I want my Shopify orders, customers, and products loaded into MotherDuck on a
+  schedule, without storing a long-lived Admin API token anywhere. Help me adapt
+  the "Ingest Shopify Orders and Products as a Flight" recipe to my own data and
+  use case, using it as a guide:
+  https://motherduck.com/docs/cookbook/flight-shopify-ingest
+published_date: 2026-08-27
+---
+
+# Ingest Shopify Orders and Products as a Flight
+
+A single-file Flight that loads Shopify into MotherDuck with
+[dlt's Shopify source](https://dlthub.com/docs/dlt-ecosystem/verified-sources/shopify).
+It shows two MotherDuck patterns worth stealing: running a dlt **verified source**
+inside a Flight even though `source_code` is a single file, and holding only OAuth
+client credentials in a secret while each run mints its own short-lived API token.
+
+Everything is driven by Flight config, so you adapt it by setting config values
+rather than editing code.
+
+## How it works
+
+`flight.py` runs a fixed sequence:
+
+1. **Read config.** `SHOP_URL` is required; database, dataset, resources,
+   `API_VERSION`, and `START_DATE` all have defaults.
+2. **Create the destination database.** dlt runs `ATTACH IF NOT EXISTS` and
+   `CREATE SCHEMA IF NOT EXISTS`, but never creates the database, so the Flight
+   does that first. Skipping it fails the load with a catalog error.
+3. **Disable dlt's external-scheduler requirement.** See Caveats: without this
+   the source refuses to run outside Airflow.
+4. **Mint an Admin API token.** A `client_credentials` grant against
+   `{shop_url}/admin/oauth/access_token` returns a token valid for 24 hours. The
+   granted scopes are logged; the token never is.
+5. **Load with dlt.** `shopify_source(...)` with the selected resources, written
+   through Parquet loader files. Each resource merges on `id` and loads
+   incrementally on `updated_at`, so re-runs don't duplicate rows.
+6. **Record the run.** One row per run in `RUN_LEDGER_TABLE` with the resources
+   loaded and dlt's load package summary.
+
+The verified source can't be pasted into a Flight, because `dlt init shopify_dlt`
+scaffolds several modules while a Flight is one file. Instead `requirements.txt`
+installs the `verified-sources` repository straight from a pinned GitHub archive,
+which makes the connector importable as `sources.shopify_dlt`.
+
+## Questions to answer
+
+- What is the store's canonical `.myshopify.com` URL? A custom storefront domain
+  does not serve the Admin API.
+- Which resources are needed: `products`, `orders`, `customers`, or a subset?
+  Grant only the matching read scopes.
+- Are the app and the store in the **same** Shopify organization? The client
+  credentials grant requires it.
+- Which MotherDuck database and dataset should receive the tables?
+- How far back should the first load reach, and does the app hold
+  `read_all_orders` if that is more than 60 days?
+- What schedule (cron, UTC) matches how often the store changes?
+
+## Caveats
+
+- **The source requires an external scheduler unless you turn that off.** Every
+  `shopify_dlt` resource sets `allow_external_schedulers=True`, which tells dlt to
+  take its load window from an orchestrator. Despite the name dlt treats it as a
+  requirement, so outside Airflow, and with no `DLT_INTERVAL_START`/`DLT_INTERVAL_END`
+  pair, the run fails with `ExternalSchedulerNotAvailable`. The Flight overrides
+  `TimeIntervalContext` to switch it off for all resources at once. Re-declaring
+  each resource's cursor also works but replaces it wholesale and silently drops
+  the source's `end_value`, so a bounded backfill would lose its upper bound.
+- **Orders are capped at 60 days without `read_all_orders`.** A Shopify scope
+  restriction, not a dlt one, and it fails quietly by returning fewer rows.
+- **The default `api_version` ages out.** The source itself defaults to `2023-10`
+  and Shopify removes versions roughly a year after release, so this template
+  pins `API_VERSION` and you should revisit it when you move the source pin.
+- **Legacy custom apps are gone.** Shopify stopped allowing new admin-created
+  custom apps on 2026-01-01, so there is no permanent `shpat_` token to paste for
+  a new setup. Existing tokens still work: pass one through a secret param named
+  `SOURCES__SHOPIFY_DLT__PRIVATE_APP_PASSWORD` and skip the exchange.
+- **Only three resources exist.** Inventory, fulfillments, discounts, and payouts
+  are not covered. Use dlt's REST API source for those.
+- **Money fields arrive as strings.** Shopify returns decimal strings, so cast
+  before doing arithmetic.
+- **Pin the source archive.** The `verified-sources` repository is not on PyPI and
+  its tags trail the default branch. A Flight reinstalls dependencies on every
+  run, so an unpinned `master.tar.gz` could change the connector between runs of
+  a Flight nobody touched.
+- **The install is heavy.** The package depends on `dlt[bigquery, duckdb]`, so
+  every run pulls the Google Cloud libraries too.
+
+## What you'll adjust
+
+No code edits are required. Everything is read from Flight config/env, plus a
+MotherDuck Flights secret holding the OAuth client credentials.
+
+| Knob | Default | Purpose |
+|---|---|---|
+| `SHOP_URL` | (required) | Canonical store URL, `https://<store>.myshopify.com`. |
+| `RESOURCES` | `products,orders,customers` | Comma-separated subset to load. |
+| `DESTINATION_DATABASE` | `shopify` | MotherDuck database, created if absent. |
+| `DATASET_NAME` | `shopify_raw` | dlt dataset (schema) holding the tables. |
+| `PIPELINE_NAME` | `flights_shopify_ingest` | dlt pipeline name, which owns incremental state. |
+| `API_VERSION` | `2026-04` | Admin API version. Use a currently supported one. |
+| `START_DATE` | `2024-01-01` | Lower bound for the first incremental load. |
+| `RUN_LEDGER_TABLE` | `shopify_ingest_runs` | Ledger table in `<database>.main`; validated as an identifier. |
+| `SHOPIFY_SECRET_NAME` | `shopify` | Name of the Flights secret to read credentials from. |
+| `shopify` **secret** | (required) | `TYPE flights` secret with params `CLIENT_ID` and `CLIENT_SECRET`. |
+
+Credentials are read from `<secret_name>_CLIENT_ID` and `<secret_name>_CLIENT_SECRET`,
+falling back to the bare `CLIENT_ID` / `CLIENT_SECRET` aliases.
+
+## Run it
+
+You need a MotherDuck account and token, plus a Shopify Dev Dashboard app with
+**Custom distribution** installed on your store. Create the app under **Apps** in
+the [Dev Dashboard](https://dev.shopify.com/dashboard), add the read scopes you
+need on an app version, release it, install it on the store, then copy the Client
+ID and Secret from **App settings**.
+
+Start with `products` only: it is the one resource that is not protected customer
+data, so it isolates credential problems from scope problems.
+
+```bash
+export MOTHERDUCK_TOKEN=your_token_here
+export CLIENT_ID=your_client_id
+export CLIENT_SECRET=your_client_secret
+SHOP_URL=https://your-store.myshopify.com \
+RESOURCES=products \
+DESTINATION_DATABASE=shopify_test \
+  uv run --with-requirements requirements.txt flight.py
+```
+
+The run logs the granted scopes, then dlt's load summary. If a resource comes back
+empty, check the logged scopes first.
+
+### Deploy as a Flight
+
+Store the client credentials as a **Flights secret** named `shopify` (UI:
+[Settings > Secrets](https://app.motherduck.com/settings/secrets), type
+**Flights**, params `CLIENT_ID` and `CLIENT_SECRET`). Or with SQL from a
+write-enabled connection, since read-only connections reject `CREATE SECRET`:
+
+```sql
+CREATE SECRET shopify IN motherduck (
+  TYPE flights,
+  PARAMS MAP {
+    'CLIENT_ID': 'your_client_id',
+    'CLIENT_SECRET': 'your_client_secret'
+  }
+);
+```
+
+To keep the literal secret out of SQL and shell history, run that from the
+**duckdb CLI** with the values in env vars, where `getenv()` resolves
+client-side:
+
+```sql
+CREATE SECRET shopify IN motherduck (
+  TYPE flights,
+  PARAMS MAP {
+    'CLIENT_ID': getenv('SHOPIFY_CLIENT_ID'),
+    'CLIENT_SECRET': getenv('SHOPIFY_CLIENT_SECRET')
+  }
+);
+```
+
+Create the secret **before** the Flight: `MD_CREATE_FLIGHT` rejects an unknown
+name with `user_secret not found`.
+
+Then create the Flight with the `MD_CREATE_FLIGHT` SQL function (no deploy SQL is
+checked in; adapt the arguments), passing:
+
+- `name`: a Flight name, for example `shopify-ingest`
+- `source_code`: `flight.py`
+- `requirements_txt`: `requirements.txt`
+- `flight_secret_names`: `["shopify"]` so the client credentials reach the run
+- `config`: at least `SHOP_URL`, plus any other knobs above
+
+A MotherDuck token is attached to the Flight automatically and injected at run
+time as `MOTHERDUCK_TOKEN`; no token argument is needed.
+
+Create without a schedule, run once with `MD_RUN_FLIGHT(flight_id := ...)` (the id
+is returned by `MD_CREATE_FLIGHT` and listed by `MD_FLIGHTS()`), and confirm the
+dataset has tables and the ledger has a new row. Then add a schedule with
+`MD_UPDATE_FLIGHT`. A daily cron suits most stores.
+
+Verify a load, joining orders to their line items through dlt's parent/child keys:
+
+```sql
+SELECT
+    items.title,
+    sum(items.quantity) AS units,
+    sum(items.quantity * items.price::DECIMAL(12, 2)) AS revenue
+FROM shopify.shopify_raw.orders AS orders
+JOIN shopify.shopify_raw.orders__line_items AS items
+    ON items._dlt_parent_id = orders._dlt_id
+WHERE orders.created_at >= current_date - INTERVAL 30 DAY
+GROUP BY ALL
+ORDER BY revenue DESC
+LIMIT 20;
+```
+
+## Security
+
+- **No long-lived API token anywhere.** The secret holds only the OAuth client ID
+  and secret. Each run exchanges them for a token that expires in 24 hours, and
+  the token is never written to config, a table, or the log.
+- **Keep the literal secret out of history.** Prefer the duckdb-CLI `getenv()`
+  form above, or the Settings UI, so the raw value is never typed into SQL text.
+- **Least privilege.** Grant only the read scopes matching the resources you
+  load. The run logs the scopes it received so you can confirm the app is not
+  over-permissioned.
+- **Rotate on exposure.** Shopify's App settings page has a **Rotate** action for
+  the client secret; update the Flights secret afterwards.
+- **Validated SQL identifiers.** `DESTINATION_DATABASE` and `RUN_LEDGER_TABLE`
+  reach `CREATE`/`INSERT` statements that cannot be parameterized, so both are
+  checked as plain identifiers before any SQL runs.
+- **Protected customer data.** `orders` and `customers` are protected customer
+  data. Custom apps have both access levels available without Shopify review,
+  unlike public apps, which is a reason to prefer Custom distribution here.
+
+## Learn more
+
+- Flight mechanics (create, run, schedule, secrets): MCP `get_flight_guide`.
+- Deeper MotherDuck/DuckDB questions: MCP `ask_docs_question`.
+- MotherDuck's Shopify integration page, which covers the same credential flow
+  with screenshots: <https://motherduck.com/docs/integrations/ingestion/shopify>
+- dlt Shopify source reference:
+  <https://dlthub.com/docs/dlt-ecosystem/verified-sources/shopify>
+- Shopify client credentials grant:
+  <https://shopify.dev/docs/apps/build/authentication-authorization/client-credentials-grant>
+- Shopify Admin API versioning: <https://shopify.dev/docs/api/usage/versioning>
+- Files: `flight.py` (the Flight source), `requirements.txt` (`duckdb`, `dlt`
+  with the MotherDuck destination, `httpx` for the token exchange, and the pinned
+  `verified-sources` archive that provides `sources.shopify_dlt`).

--- a/flight-plans/flight-shopify-ingest/flight.py
+++ b/flight-plans/flight-shopify-ingest/flight.py
@@ -1,0 +1,170 @@
+import os
+import re
+
+import dlt
+import duckdb
+import httpx
+from dlt.common.configuration.container import Container
+from dlt.extract.incremental.context import TimeIntervalContext
+
+from sources.shopify_dlt import shopify_source
+
+
+IDENTIFIER_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
+SHOPIFY_RESOURCES = ("products", "orders", "customers")
+
+
+def get_access_token(shop_url: str, client_id: str, client_secret: str) -> str:
+    # A Dev Dashboard app exposes a client ID and secret, not a permanent Admin
+    # API token. The client credentials grant trades them for a token that lives
+    # 24 hours, which suits a Flight: each run mints its own and finishes well
+    # inside that window, so no token is ever stored.
+    response = httpx.post(
+        f"{shop_url}/admin/oauth/access_token",
+        data={
+            "grant_type": "client_credentials",
+            "client_id": client_id,
+            "client_secret": client_secret,
+        },
+        timeout=30,
+    )
+    if response.status_code != 200:
+        # Surface Shopify's own message. `shop_not_permitted` means the app and
+        # the store sit in different Shopify organizations, which this grant
+        # does not support; use the authorization code grant for that case.
+        raise RuntimeError(
+            f"Shopify token exchange failed: HTTP {response.status_code}: {response.text[:400]}"
+        )
+    payload = response.json()
+    # Log the granted scopes, never the token. A short load that returns no rows
+    # is usually a missing scope rather than an empty store.
+    print(f"granted scopes: {payload.get('scope')!r}, expires_in={payload.get('expires_in')}")
+    return payload["access_token"]
+
+
+def main() -> None:
+    # Every knob is read from Flight config/env, so you adapt this template by
+    # setting config values rather than editing code. Only SHOP_URL and the
+    # credential secret are required.
+    shop_url = env("SHOP_URL", "").rstrip("/")
+    if not shop_url:
+        raise ValueError(
+            "SHOP_URL is required, for example https://your-store.myshopify.com. "
+            "Use the canonical .myshopify.com host, not a custom storefront domain."
+        )
+    database = validate_identifier("DESTINATION_DATABASE", env("DESTINATION_DATABASE", "shopify"))
+    dataset_name = env("DATASET_NAME", "shopify_raw")
+    pipeline_name = env("PIPELINE_NAME", "flights_shopify_ingest")
+    api_version = env("API_VERSION", "2026-04")
+    start_date = env("START_DATE", "2024-01-01")
+    ledger_table = validate_identifier("RUN_LEDGER_TABLE", env("RUN_LEDGER_TABLE", "shopify_ingest_runs"))
+    resources = [
+        name.strip()
+        for name in env("RESOURCES", ",".join(SHOPIFY_RESOURCES)).split(",")
+        if name.strip()
+    ]
+    unknown = sorted(set(resources) - set(SHOPIFY_RESOURCES))
+    if unknown:
+        raise ValueError(
+            f"RESOURCES contains {unknown}; the Shopify source only provides {list(SHOPIFY_RESOURCES)}"
+        )
+
+    # dlt writes working files under HOME; a Flight has a writable /tmp.
+    os.environ.setdefault("HOME", "/tmp")
+    # Point the dlt MotherDuck destination at our database. The injected
+    # MOTHERDUCK_TOKEN supplies the credential, so no token appears here.
+    os.environ["DESTINATION__MOTHERDUCK__CREDENTIALS__DATABASE"] = database
+
+    # Create the destination database so dlt has a catalog to build the dataset
+    # in; dlt creates the dataset (schema) and tables, but not the database.
+    con = duckdb.connect("md:")
+    con.execute(f"CREATE DATABASE IF NOT EXISTS {database}")
+
+    # Every shopify_dlt resource declares allow_external_schedulers=True, which
+    # tells dlt to take its load window from an orchestrator rather than its own
+    # state. Despite the name dlt treats it as a requirement: outside Airflow,
+    # and without a DLT_INTERVAL_START/DLT_INTERVAL_END pair, the run fails with
+    # ExternalSchedulerNotAvailable. This override switches it off for every
+    # resource at once and leaves dlt's incremental state in charge. Prefer it
+    # over re-declaring each cursor, which would drop the source's end_value.
+    Container()[TimeIntervalContext] = TimeIntervalContext(allow_external_schedulers=False)
+
+    access_token = get_access_token(
+        shop_url,
+        credential("CLIENT_ID"),
+        credential("CLIENT_SECRET"),
+    )
+
+    pipeline = dlt.pipeline(
+        pipeline_name=pipeline_name,
+        destination="motherduck",
+        dataset_name=dataset_name,
+    )
+    source = shopify_source(
+        private_app_password=access_token,
+        shop_url=shop_url,
+        start_date=start_date,
+        api_version=api_version,
+    ).with_resources(*resources)
+
+    load_info = pipeline.run(
+        source,
+        # Prefer Parquet loader files over row-wise insert_values so larger
+        # stores stay on a bulk-loading path. Keep this unless you have measured
+        # a reason to change it.
+        loader_file_format="parquet",
+    )
+
+    # Record the dlt load package summary so each run leaves an audit trail. The
+    # ledger lives in the database's main schema, separate from the dlt dataset.
+    con.execute(f"CREATE SCHEMA IF NOT EXISTS {database}.main")
+    con.execute(
+        f"""
+        CREATE TABLE IF NOT EXISTS {database}.main.{ledger_table} (
+            run_at TIMESTAMPTZ,
+            pipeline_name VARCHAR,
+            destination_dataset VARCHAR,
+            resources VARCHAR,
+            load_summary VARCHAR
+        )
+        """
+    )
+    con.execute(
+        f"INSERT INTO {database}.main.{ledger_table} VALUES (current_timestamp, ?, ?, ?, ?)",
+        [pipeline_name, dataset_name, ",".join(resources), str(load_info)],
+    )
+    con.close()
+    print(load_info)
+
+
+def env(name: str, default: str) -> str:
+    value = os.environ.get(name, default).strip()
+    return value or default
+
+
+def credential(key: str) -> str:
+    # A Flight secret injects each key as `<secret_name>_<KEY>` and, when safe,
+    # as the bare `<KEY>`. Prefer the namespaced form so two secrets defining the
+    # same key stay distinct, then fall back to the bare alias.
+    secret_name = env("SHOPIFY_SECRET_NAME", "shopify")
+    for candidate in (f"{secret_name}_{key}", key):
+        value = os.environ.get(candidate, "").strip()
+        if value:
+            return value
+    raise KeyError(
+        f"Missing Shopify {key}. Expected {secret_name}_{key} or {key} from a "
+        f"TYPE flights secret named {secret_name!r}."
+    )
+
+
+def validate_identifier(name: str, value: str) -> str:
+    # The database and ledger table names flow into CREATE/INSERT statements that
+    # cannot be parameterized, so reject anything that is not a plain SQL
+    # identifier before any SQL runs.
+    if not IDENTIFIER_RE.fullmatch(value):
+        raise ValueError(f"{name} must be a simple SQL identifier, got {value!r}")
+    return value
+
+
+if __name__ == "__main__":
+    main()

--- a/flight-plans/flight-shopify-ingest/requirements.txt
+++ b/flight-plans/flight-shopify-ingest/requirements.txt
@@ -1,0 +1,4 @@
+duckdb==1.5.5
+dlt[motherduck]==1.30.0
+httpx==0.28.1
+dlt-verified-sources @ https://github.com/dlt-hub/verified-sources/archive/3957506893a7da821dbcc6acd51c7ca4475d1f53.tar.gz

--- a/scripts/build-catalog.py
+++ b/scripts/build-catalog.py
@@ -87,6 +87,8 @@ ALLOWED_TAGS = {
     "slack",
     # crm and marketing
     "hubspot",
+    # ecommerce
+    "shopify",
     # external databases
     "postgres",
     "sqlite",


### PR DESCRIPTION
## What this adds

`flight-plans/flight-shopify-ingest`: a single-file Flight that loads Shopify products, orders, and customers into MotherDuck with dlt's Shopify verified source, plus `shopify` in `ALLOWED_TAGS`.

## Why it's a template worth having

It demonstrates two patterns that aren't obvious and that neither existing dlt template covers:

- **Running a dlt *verified source* inside a Flight.** `dlt init shopify_dlt` scaffolds several modules, but a Flight's `source_code` is one file, so it can't be pasted in. `requirements.txt` instead installs the `verified-sources` repo from a pinned GitHub archive, which makes the connector importable as `sources.shopify_dlt`.
- **Holding no long-lived API token.** Shopify stopped allowing new admin-created custom apps on 2026-01-01, so there's no permanent `shpat_` token to paste for a new setup. The secret holds only OAuth client ID and secret, and each run mints a 24-hour Admin API token via the client credentials grant. A 24h token is awkward as stored config but a natural fit for a scheduled Flight.

## Verified against a live store

Deployed as a Flight and run on a real store, not just linted:

- `products`, `orders`, `customers` all load (91 / 174 / 287 rows, 743 line items)
- the run ledger gets its row
- a repeat run leaves counts unchanged with `rows == distinct ids`, so incremental state and the merge disposition both behave
- the granted-scopes log line confirms the token exchange returns `expires_in=86399`

Repo validation also passes: `build-catalog.py`, the schema check, and `tests/test_build_catalog.py` + `tests/test_catalog_workflow.py` (13 passed).

## Reviewer notes

The template carries a workaround worth a look. Every `shopify_dlt` resource sets `allow_external_schedulers=True`, which makes dlt *require* an Airflow-style interval and otherwise raise `ExternalSchedulerNotAvailable`, so the source will not run in a Flight untouched. The Flight overrides `TimeIntervalContext` to switch it off for all resources at once. I first did this per resource with `apply_hints(incremental=...)` and that is the wrong fix: it replaces the cursor wholesale and silently drops the source's `end_value`, so a bounded backfill would lose its upper bound.

`API_VERSION` is pinned to `2026-04` because the source's own default (`2023-10`) has aged out of Shopify's supported window. It will need revisiting whenever the source pin moves.

Companion docs PR, which covers the same credential flow with screenshots: motherduckdb/motherduck-docs#1894

🤖 Generated with [Claude Code](https://claude.com/claude-code)
